### PR TITLE
Implement geometry shaders (Battle-tested Edition)

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics_breakpoints.cpp
@@ -36,6 +36,8 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const {
                 {Pica::DebugContext::Event::IncomingPrimitiveBatch, tr("Incoming primitive batch")},
                 {Pica::DebugContext::Event::FinishedPrimitiveBatch, tr("Finished primitive batch")},
                 {Pica::DebugContext::Event::VertexShaderInvocation, tr("Vertex shader invocation")},
+                {Pica::DebugContext::Event::GeometryShaderInvocation,
+                 tr("Geometry shader invocation")},
                 {Pica::DebugContext::Event::IncomingDisplayTransfer,
                  tr("Incoming display transfer")},
                 {Pica::DebugContext::Event::GSPCommandProcessed, tr("GSP command processed")},

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -522,8 +522,7 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     info.labels.insert({entry_point, "main"});
 
     // Generate debug information
-    debug_data = Pica::g_state.vs.ProduceDebugInfo(input_vertex, num_attributes, shader_config,
-                                                   shader_setup);
+    debug_data = Pica::g_state.vs.ProduceDebugInfo(input_vertex, num_attributes, shader_config);
 
     // Reload widget state
     for (int attr = 0; attr < num_attributes; ++attr) {

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -134,7 +134,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (immediate_attribute_id >= regs.vs.num_input_attributes + 1) {
                     immediate_attribute_id = 0;
 
-                    Shader::UnitState<false> shader_unit;
+                    auto& shader_unit = Shader::GetShaderUnit(false);
                     g_state.vs.Setup();
 
                     // Send to vertex shader
@@ -234,8 +234,11 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         unsigned int vertex_cache_pos = 0;
         vertex_cache_ids.fill(-1);
 
-        Shader::UnitState<false> shader_unit;
+        auto& vs_shader_unit = Shader::GetShaderUnit(false);
         g_state.vs.Setup();
+
+        auto& gs_unit_state = Shader::GetShaderUnit(true);
+        g_state.gs.Setup();
 
         for (unsigned int index = 0; index < regs.num_vertices; ++index) {
             // Indexed rendering doesn't use the start offset
@@ -248,6 +251,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             ASSERT(vertex != -1);
 
             bool vertex_cache_hit = false;
+            Shader::OutputRegisters output_registers = {};
 
             if (is_indexed) {
                 if (g_debug_context && Pica::g_debug_context->recorder) {
@@ -256,11 +260,15 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                                               size);
                 }
 
-                for (unsigned int i = 0; i < VERTEX_CACHE_SIZE; ++i) {
-                    if (vertex == vertex_cache_ids[i]) {
-                        output_vertex = vertex_cache[i];
-                        vertex_cache_hit = true;
-                        break;
+                // Cache lookup.
+                // Disabled while GS is active to force valid output_registers.
+                if (!Shader::UseGS()) {
+                    for (unsigned int i = 0; i < VERTEX_CACHE_SIZE; ++i) {
+                        if (vertex == vertex_cache_ids[i]) {
+                            output_vertex = vertex_cache[i];
+                            vertex_cache_hit = true;
+                            break;
+                        }
                     }
                 }
             }
@@ -274,26 +282,77 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (g_debug_context)
                     g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                              (void*)&input);
-                g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes(), regs.vs);
+                g_state.vs.Run(vs_shader_unit, input, loader.GetNumTotalAttributes(), regs.vs);
+                output_registers = vs_shader_unit.output_registers;
 
                 // Retrieve vertex from register data
-                output_vertex = shader_unit.output_registers.ToVertex(regs.vs);
+                output_vertex = output_registers.ToVertex(regs.vs);
 
-                if (is_indexed) {
-                    vertex_cache[vertex_cache_pos] = output_vertex;
-                    vertex_cache_ids[vertex_cache_pos] = vertex;
-                    vertex_cache_pos = (vertex_cache_pos + 1) % VERTEX_CACHE_SIZE;
+                // Caching.
+                // Disabled while GS is active as cache lookup is also deactivated.
+                if (!Shader::UseGS()) {
+                    if (is_indexed) {
+                        vertex_cache[vertex_cache_pos] = output_vertex;
+                        vertex_cache_ids[vertex_cache_pos] = vertex;
+                        vertex_cache_pos = (vertex_cache_pos + 1) % VERTEX_CACHE_SIZE;
+                    }
                 }
             }
 
-            // Send to renderer
+            // Helper to send triangle to renderer
             using Pica::Shader::OutputVertex;
             auto AddTriangle = [](const OutputVertex& v0, const OutputVertex& v1,
                                   const OutputVertex& v2) {
                 VideoCore::g_renderer->Rasterizer()->AddTriangle(v0, v1, v2);
             };
 
-            primitive_assembler.SubmitVertex(output_vertex, AddTriangle);
+            if (Shader::UseGS()) {
+
+                auto& regs = g_state.regs;
+                auto& gs_regs = g_state.regs.gs;
+                auto& gs_buf = g_state.gs_input_buffer;
+
+                // Vertex Shader Outputs are converted into Geometry Shader inputs by
+                // filling up a buffer
+                // For example, if we have a geoshader that takes 6 inputs, and the
+                // vertex shader outputs 2 attributes
+                // It would take 3 vertices to fill up the Geometry Shader buffer
+                unsigned int gs_input_count = gs_regs.num_input_attributes + 1;
+                unsigned int vs_output_count = regs.vs_outmap_total2 + 1;
+                ASSERT_MSG(regs.vs_outmap_total1 == regs.vs_outmap_total2,
+                           "VS_OUTMAP_TOTAL1 and VS_OUTMAP_TOTAL2 don't match!");
+                // copy into the geoshader buffer
+                for (unsigned int i = 0; i < vs_output_count; i++) {
+                    if (gs_buf.index >= gs_input_count) {
+                        // TODO(ds84182): LOG_ERROR()
+                        ASSERT_MSG(false, "Number of GS inputs (%d) is not divisible by "
+                                          "number of VS outputs (%d)",
+                                   gs_input_count, vs_output_count);
+                        continue;
+                    }
+                    gs_buf.buffer.attr[gs_buf.index++] = output_registers.value[i];
+                }
+
+                if (gs_buf.index >= gs_input_count) {
+
+                    // b15 will be false when a new primitive starts and then switch to
+                    // true at some point
+                    // TODO: Test how this works exactly on hardware
+                    g_state.gs.uniforms.b[15] |= (index > 0);
+
+                    // Process Geometry Shader
+                    if (g_debug_context)
+                        g_debug_context->OnEvent(DebugContext::Event::GeometryShaderInvocation,
+                                                 static_cast<void*>(&gs_buf.buffer));
+                    gs_unit_state.emit_triangle_callback = AddTriangle;
+                    g_state.gs.Run(gs_unit_state, gs_buf.buffer, gs_input_count, regs.gs);
+                    gs_unit_state.emit_triangle_callback = nullptr;
+
+                    gs_buf.index = 0;
+                }
+            } else {
+                primitive_assembler.SubmitVertex(output_vertex, AddTriangle);
+            }
         }
 
         for (auto& range : memory_accesses.ranges) {

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -30,10 +30,6 @@ namespace Pica {
 
 namespace CommandProcessor {
 
-static int float_regs_counter = 0;
-
-static u32 uniform_write_buffer[4];
-
 static int default_attr_counter = 0;
 
 static u32 default_attr_write_buffer[3];
@@ -309,22 +305,23 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     }
 
     case PICA_REG_INDEX(vs.bool_uniforms):
-        for (unsigned i = 0; i < 16; ++i)
-            g_state.vs.uniforms.b[i] = (regs.vs.bool_uniforms.Value() & (1 << i)) != 0;
-
+        Shader::WriteUniformBoolReg(false, value);
         break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[1], 0x2b2):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[2], 0x2b3):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[3], 0x2b4): {
-        int index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
         auto values = regs.vs.int_uniforms[index];
-        g_state.vs.uniforms.i[index] = Math::Vec4<u8>(values.x, values.y, values.z, values.w);
-        LOG_TRACE(HW_GPU, "Set integer uniform %d to %02x %02x %02x %02x", index, values.x.Value(),
-                  values.y.Value(), values.z.Value(), values.w.Value());
+        Shader::WriteUniformIntReg(false, index,
+                                   Math::Vec4<u8>(values.x, values.y, values.z, values.w));
         break;
     }
+
+    case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.setup, 0x2c0):
+        Shader::WriteUniformFloatSetupReg(false, value);
+        break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[0], 0x2c1):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[1], 0x2c2):
@@ -334,51 +331,15 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[5], 0x2c6):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[6], 0x2c7):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[7], 0x2c8): {
-        auto& uniform_setup = regs.vs.uniform_setup;
-
-        // TODO: Does actual hardware indeed keep an intermediate buffer or does
-        //       it directly write the values?
-        uniform_write_buffer[float_regs_counter++] = value;
-
-        // Uniforms are written in a packed format such that four float24 values are encoded in
-        // three 32-bit numbers. We write to internal memory once a full such vector is
-        // written.
-        if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
-            (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
-            float_regs_counter = 0;
-
-            auto& uniform = g_state.vs.uniforms.f[uniform_setup.index];
-
-            if (uniform_setup.index > 95) {
-                LOG_ERROR(HW_GPU, "Invalid VS uniform index %d", (int)uniform_setup.index);
-                break;
-            }
-
-            // NOTE: The destination component order indeed is "backwards"
-            if (uniform_setup.IsFloat32()) {
-                for (auto i : {0, 1, 2, 3})
-                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
-            } else {
-                // TODO: Untested
-                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
-                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
-                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
-                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
-                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
-                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
-            }
-
-            LOG_TRACE(HW_GPU, "Set uniform %x to (%f %f %f %f)", (int)uniform_setup.index,
-                      uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
-                      uniform.w.ToFloat32());
-
-            // TODO: Verify that this actually modifies the register!
-            uniform_setup.index.Assign(uniform_setup.index + 1);
-        }
+        Shader::WriteUniformFloatReg(false, value);
         break;
     }
 
     // Load shader program code
+    case PICA_REG_INDEX_WORKAROUND(vs.program.offset, 0x2cb):
+        Shader::WriteProgramCodeOffset(false, value);
+        break;
+
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[0], 0x2cc):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[1], 0x2cd):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[2], 0x2ce):
@@ -387,12 +348,15 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[5], 0x2d1):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[6], 0x2d2):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[7], 0x2d3): {
-        g_state.vs.program_code[regs.vs.program.offset] = value;
-        regs.vs.program.offset++;
+        Shader::WriteProgramCode(false, value);
         break;
     }
 
     // Load swizzle pattern data
+    case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.offset, 0x2d5):
+        Shader::WriteSwizzlePatternsOffset(false, value);
+        break;
+
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[0], 0x2d6):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[1], 0x2d7):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[2], 0x2d8):
@@ -401,8 +365,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[5], 0x2db):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[6], 0x2dc):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[7], 0x2dd): {
-        g_state.vs.swizzle_data[regs.vs.swizzle_patterns.offset] = value;
-        regs.vs.swizzle_patterns.offset++;
+        Shader::WriteSwizzlePatterns(false, value);
         break;
     }
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -145,7 +145,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     if (g_debug_context)
                         g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                                  static_cast<void*>(&immediate_input));
-                    g_state.vs.Run(shader_unit, immediate_input, regs.vs.num_input_attributes + 1);
+                    g_state.vs.Run(shader_unit, immediate_input, regs.vs.num_input_attributes + 1,
+                                   regs.vs);
                     Shader::OutputVertex output_vertex =
                         shader_unit.output_registers.ToVertex(regs.vs);
 
@@ -277,7 +278,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (g_debug_context)
                     g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                              (void*)&input);
-                g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes());
+                g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes(), regs.vs);
 
                 // Retrieve vertex from register data
                 output_vertex = shader_unit.output_registers.ToVertex(regs.vs);

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -304,6 +304,71 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         break;
     }
 
+    case PICA_REG_INDEX(gs.bool_uniforms):
+        Shader::WriteUniformBoolReg(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[1], 0x282):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[2], 0x283):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[3], 0x284): {
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281));
+        auto values = regs.gs.int_uniforms[index];
+        Shader::WriteUniformIntReg(true, index,
+                                   Math::Vec4<u8>(values.x, values.y, values.z, values.w));
+        break;
+    }
+
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.setup, 0x290):
+        Shader::WriteUniformFloatSetupReg(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[0], 0x291):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[1], 0x292):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[2], 0x293):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[3], 0x294):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[4], 0x295):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[5], 0x296):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[6], 0x297):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[7], 0x298): {
+        Shader::WriteUniformFloatReg(true, value);
+        break;
+    }
+
+    // Load shader program code
+    case PICA_REG_INDEX_WORKAROUND(gs.program.offset, 0x29b):
+        Shader::WriteProgramCodeOffset(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[0], 0x29c):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[1], 0x29d):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[2], 0x29e):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[3], 0x29f):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[4], 0x2a0):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[5], 0x2a1):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[6], 0x2a2):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[7], 0x2a3): {
+        Shader::WriteProgramCode(true, value);
+        break;
+    }
+
+    // Load swizzle pattern data
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.offset, 0x2a5):
+        Shader::WriteSwizzlePatternsOffset(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[0], 0x2a6):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[1], 0x2a7):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[2], 0x2a8):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[3], 0x2a9):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[4], 0x2aa):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[5], 0x2ab):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[6], 0x2ac):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[7], 0x2ad): {
+        Shader::WriteSwizzlePatterns(true, value);
+        break;
+    }
+
     case PICA_REG_INDEX(vs.bool_uniforms):
         Shader::WriteUniformBoolReg(false, value);
         break;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -39,6 +39,7 @@ public:
         IncomingPrimitiveBatch,
         FinishedPrimitiveBatch,
         VertexShaderInvocation,
+        GeometryShaderInvocation,
         IncomingDisplayTransfer,
         GSPCommandProcessed,
         BufferSwapped,

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -1128,7 +1128,7 @@ struct Regs {
     // Number of vertices to render
     u32 num_vertices;
 
-    INSERT_PADDING_WORDS(0x1);
+    BitField<0, 2, u32> using_geometry_shader;
 
     // The index of the first vertex to render
     u32 vertex_offset;
@@ -1176,7 +1176,11 @@ struct Regs {
         }
     } command_buffer;
 
-    INSERT_PADDING_WORDS(0x07);
+    INSERT_PADDING_WORDS(0x06);
+
+    enum class VSComMode : u32 { Shared = 0, Exclusive = 1 };
+
+    VSComMode vs_com_mode;
 
     enum class GPUMode : u32 {
         Drawing = 0,
@@ -1185,7 +1189,17 @@ struct Regs {
 
     GPUMode gpu_mode;
 
-    INSERT_PADDING_WORDS(0x18);
+    INSERT_PADDING_WORDS(0x4);
+
+    BitField<0, 4, u32> vs_outmap_total1;
+
+    INSERT_PADDING_WORDS(0x6);
+
+    BitField<0, 4, u32> vs_outmap_total2;
+
+    BitField<0, 4, u32> gsh_misc0;
+
+    INSERT_PADDING_WORDS(0xB);
 
     enum class TriangleTopology : u32 {
         List = 0,
@@ -1194,7 +1208,10 @@ struct Regs {
         Shader = 3, // Programmable setup unit implemented in a geometry shader
     };
 
-    BitField<8, 2, TriangleTopology> triangle_topology;
+    union {
+        BitField<0, 4, u32> vs_outmap_count;
+        BitField<8, 2, TriangleTopology> triangle_topology;
+    };
 
     u32 restart_primitive;
 
@@ -1213,8 +1230,10 @@ struct Regs {
         INSERT_PADDING_WORDS(0x4);
 
         union {
-            // Number of input attributes to shader unit - 1
-            BitField<0, 4, u32> num_input_attributes;
+            BitField<0, 4, u32>
+                num_input_attributes; // Number of input attributes to shader unit - 1
+            BitField<8, 4, u32> use_subdivision;
+            BitField<24, 8, u32> use_geometry_shader;
         };
 
         // Offset to shader program entry point (in words)
@@ -1391,7 +1410,11 @@ ASSERT_REG_POSITION(trigger_draw, 0x22e);
 ASSERT_REG_POSITION(trigger_draw_indexed, 0x22f);
 ASSERT_REG_POSITION(vs_default_attributes_setup, 0x232);
 ASSERT_REG_POSITION(command_buffer, 0x238);
+ASSERT_REG_POSITION(vs_com_mode, 0x244);
 ASSERT_REG_POSITION(gpu_mode, 0x245);
+ASSERT_REG_POSITION(vs_outmap_total1, 0x24A);
+ASSERT_REG_POSITION(vs_outmap_total2, 0x251);
+ASSERT_REG_POSITION(gsh_misc0, 0x252);
 ASSERT_REG_POSITION(triangle_topology, 0x25e);
 ASSERT_REG_POSITION(restart_primitive, 0x25f);
 ASSERT_REG_POSITION(gs, 0x280);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -1286,6 +1286,8 @@ struct Regs {
             }
 
             union {
+                u32 setup;
+
                 // Index of the next uniform to write to
                 // TODO: ctrulib uses 8 bits for this, however that seems to yield lots of invalid
                 // indices

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -73,6 +73,14 @@ struct State {
 
     // This is constructed with a dummy triangle topology
     PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;
+
+    /// Current geometry shader state
+    struct GeometryShaderState {
+        // Buffer used for geometry shader inputs
+        Shader::InputVertex buffer;
+        // The current index into the buffer
+        unsigned int index;
+    } gs_input_buffer;
 };
 
 extern State g_state; ///< Current Pica state

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -20,6 +20,8 @@ struct State {
     /// Pica registers
     Regs regs;
 
+    Shader::UnitState<false> shader_units[4];
+
     Shader::ShaderSetup vs;
     Shader::ShaderSetup gs;
 

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -17,7 +17,6 @@ template <typename VertexType>
 void PrimitiveAssembler<VertexType>::SubmitVertex(VertexType& vtx,
                                                   TriangleHandler triangle_handler) {
     switch (topology) {
-    // TODO: Figure out what's different with TriangleTopology::Shader.
     case Regs::TriangleTopology::List:
     case Regs::TriangleTopology::Shader:
         if (buffer_index < 2) {

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -156,6 +156,164 @@ DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_
     return state.debug;
 }
 
+bool SharedGS() {
+    return g_state.regs.vs_com_mode == Pica::Regs::VSComMode::Shared;
+}
+
+void WriteUniformBoolReg(bool gs, u32 value) {
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    ASSERT(setup.uniforms.b.size() == 16);
+    for (unsigned i = 0; i < 16; ++i)
+        setup.uniforms.b[i] = (value & (1 << i)) != 0;
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteUniformBoolReg(true, value);
+    }
+}
+
+void WriteUniformIntReg(bool gs, unsigned index, const Math::Vec4<u8>& values) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    ASSERT(index < setup.uniforms.i.size());
+    setup.uniforms.i[index] = values;
+    LOG_TRACE(HW_GPU, "Set %s integer uniform %d to %02x %02x %02x %02x", shader_type, index,
+              values.x.Value(), values.y.Value(), values.z.Value(), values.w.Value());
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteUniformIntReg(true, index, values);
+    }
+}
+
+void WriteUniformFloatSetupReg(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+
+    config.uniform_setup.setup = value;
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteUniformFloatSetupReg(true, value);
+    }
+}
+
+void WriteUniformFloatReg(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    auto& uniform_setup = config.uniform_setup;
+    auto& uniform_write_buffer = setup.uniform_write_buffer;
+    auto& float_regs_counter = setup.float_regs_counter;
+
+    // TODO: Does actual hardware indeed keep an intermediate buffer or does
+    //       it directly write the values?
+    uniform_write_buffer[float_regs_counter++] = value;
+
+    // Uniforms are written in a packed format such that four float24 values are
+    // encoded in
+    // three 32-bit numbers. We write to internal memory once a full such vector
+    // is
+    // written.
+    if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
+        (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
+        float_regs_counter = 0;
+
+        auto& uniform = setup.uniforms.f[uniform_setup.index];
+
+        if (uniform_setup.index >= 96) {
+            LOG_ERROR(HW_GPU, "Invalid %s float uniform index %d", shader_type,
+                      (int)uniform_setup.index);
+        } else {
+
+            // NOTE: The destination component order indeed is "backwards"
+            if (uniform_setup.IsFloat32()) {
+                for (auto i : {0, 1, 2, 3})
+                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
+            } else {
+                // TODO: Untested
+                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
+                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
+                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
+                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
+                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
+                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
+            }
+
+            LOG_TRACE(HW_GPU, "Set %s float uniform %x to (%f %f %f %f)", shader_type,
+                      (int)uniform_setup.index, uniform.x.ToFloat32(), uniform.y.ToFloat32(),
+                      uniform.z.ToFloat32(), uniform.w.ToFloat32());
+
+            // TODO: Verify that this actually modifies the register!
+            uniform_setup.index.Assign(uniform_setup.index + 1);
+        }
+    }
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteUniformFloatReg(true, value);
+    }
+}
+
+void WriteProgramCodeOffset(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    config.program.offset = value;
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteProgramCodeOffset(true, value);
+    }
+}
+
+void WriteProgramCode(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    if (config.program.offset >= setup.program_code.size()) {
+        LOG_ERROR(HW_GPU, "Invalid %s program offset %d", shader_type, (int)config.program.offset);
+    } else {
+        setup.program_code[config.program.offset] = value;
+        config.program.offset++;
+    }
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteProgramCode(true, value);
+    }
+}
+
+void WriteSwizzlePatternsOffset(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    config.swizzle_patterns.offset = value;
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteSwizzlePatternsOffset(true, value);
+    }
+}
+
+void WriteSwizzlePatterns(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    if (config.swizzle_patterns.offset >= setup.swizzle_data.size()) {
+        LOG_ERROR(HW_GPU, "Invalid %s swizzle pattern offset %d", shader_type,
+                  (int)config.swizzle_patterns.offset);
+    } else {
+        setup.swizzle_data[config.swizzle_patterns.offset] = value;
+        config.swizzle_patterns.offset++;
+    }
+
+    // Copy for GS in shared mode
+    if (!gs && SharedGS()) {
+        WriteSwizzlePatterns(true, value);
+    }
+}
+
 } // namespace Shader
 
 } // namespace Pica

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -314,6 +314,33 @@ void WriteSwizzlePatterns(bool gs, u32 value) {
     }
 }
 
+template <bool Debug>
+void HandleEMIT(UnitState<Debug>& state) {
+    auto& config = g_state.regs.gs;
+    auto& emit_params = state.emit_params;
+    auto& emit_buffers = state.emit_buffers;
+
+    ASSERT(emit_params.vertex_id < 3);
+
+    emit_buffers[emit_params.vertex_id] = state.output_registers;
+
+    if (emit_params.primitive_emit) {
+        ASSERT_MSG(state.emit_triangle_callback, "EMIT invoked but no handler set!");
+        OutputVertex v0 = emit_buffers[0].ToVertex(config);
+        OutputVertex v1 = emit_buffers[1].ToVertex(config);
+        OutputVertex v2 = emit_buffers[2].ToVertex(config);
+        if (emit_params.winding) {
+            state.emit_triangle_callback(v2, v1, v0);
+        } else {
+            state.emit_triangle_callback(v0, v1, v2);
+        }
+    }
+}
+
+// Explicit instantiation
+template void HandleEMIT(UnitState<false>& state);
+template void HandleEMIT(UnitState<true>& state);
+
 } // namespace Shader
 
 } // namespace Pica

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -160,6 +160,29 @@ bool SharedGS() {
     return g_state.regs.vs_com_mode == Pica::Regs::VSComMode::Shared;
 }
 
+bool UseGS() {
+    // TODO(ds84182): This would be more accurate if it looked at induvidual
+    // shader units for the geoshader bit
+    // gs_regs.input_buffer_config.use_geometry_shader == 0x08
+    ASSERT((g_state.regs.using_geometry_shader == 0) || (g_state.regs.using_geometry_shader == 2));
+    return g_state.regs.using_geometry_shader == 2;
+}
+
+UnitState<false>& GetShaderUnit(bool gs) {
+
+    // GS are always run on shader unit 3
+    if (gs) {
+        return g_state.shader_units[3];
+    }
+
+    // The worst scheduler you'll ever see!
+    // TODO: How does PICA shader scheduling work?
+    static unsigned shader_unit_scheduler = 0;
+    shader_unit_scheduler++;
+    shader_unit_scheduler %= 3; // TODO: When does it also allow use of unit 3?!
+    return g_state.shader_units[shader_unit_scheduler];
+}
+
 void WriteUniformBoolReg(bool gs, u32 value) {
     auto& setup = gs ? g_state.gs : g_state.vs;
 

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -101,6 +101,8 @@ void ShaderSetup::Setup() {
             jit_shader = shader;
             shader_map[cache_key] = std::move(shader);
         }
+    } else {
+        jit_shader.reset();
     }
 #endif // ARCHITECTURE_x86_64
 }
@@ -125,8 +127,8 @@ void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num
     state.conditional_code[1] = false;
 
 #ifdef ARCHITECTURE_x86_64
-    if (VideoCore::g_shader_jit_enabled)
-        jit_shader.lock().get()->Run(*this, state, config.main_offset);
+    if (auto shader = jit_shader.lock())
+        shader.get()->Run(*this, state, config.main_offset);
     else
         RunInterpreter(*this, state, config.main_offset);
 #else

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -77,8 +77,7 @@ OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) const {
 }
 
 #ifdef ARCHITECTURE_x86_64
-static std::unordered_map<u64, std::unique_ptr<JitShader>> shader_map;
-static const JitShader* jit_shader;
+static std::unordered_map<u64, std::shared_ptr<JitShader>> shader_map;
 #endif // ARCHITECTURE_x86_64
 
 void ClearCache() {
@@ -90,17 +89,16 @@ void ClearCache() {
 void ShaderSetup::Setup() {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
-        u64 cache_key =
-            Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
-            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data));
+        u64 cache_key = (Common::ComputeHash64(&program_code, sizeof(program_code)) ^
+                         Common::ComputeHash64(&swizzle_data, sizeof(swizzle_data)));
 
         auto iter = shader_map.find(cache_key);
         if (iter != shader_map.end()) {
-            jit_shader = iter->second.get();
+            jit_shader = iter->second;
         } else {
-            auto shader = std::make_unique<JitShader>();
-            shader->Compile();
-            jit_shader = shader.get();
+            auto shader = std::make_shared<JitShader>();
+            shader->Compile(*this);
+            jit_shader = shader;
             shader_map[cache_key] = std::move(shader);
         }
     }
@@ -109,9 +107,8 @@ void ShaderSetup::Setup() {
 
 MICROPROFILE_DEFINE(GPU_Shader, "GPU", "Shader", MP_RGB(50, 50, 240));
 
-void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num_attributes) {
-    auto& config = g_state.regs.vs;
-    auto& setup = g_state.vs;
+void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num_attributes,
+                      const Regs::ShaderConfig& config) {
 
     MICROPROFILE_SCOPE(GPU_Shader);
 
@@ -129,17 +126,16 @@ void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num
 
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled)
-        jit_shader->Run(setup, state, config.main_offset);
+        jit_shader.lock().get()->Run(*this, state, config.main_offset);
     else
-        RunInterpreter(setup, state, config.main_offset);
+        RunInterpreter(*this, state, config.main_offset);
 #else
-    RunInterpreter(setup, state, config.main_offset);
+    RunInterpreter(*this, state, config.main_offset);
 #endif // ARCHITECTURE_x86_64
 }
 
 DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_attributes,
-                                              const Regs::ShaderConfig& config,
-                                              const ShaderSetup& setup) {
+                                              const Regs::ShaderConfig& config) {
     UnitState<true> state;
 
     state.debug.max_offset = 0;
@@ -154,7 +150,7 @@ DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_
     state.conditional_code[0] = false;
     state.conditional_code[1] = false;
 
-    RunInterpreter(setup, state, config.main_offset);
+    RunInterpreter(*this, state, config.main_offset);
     return state.debug;
 }
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -26,6 +26,12 @@ namespace Pica {
 
 namespace Shader {
 
+#ifdef ARCHITECTURE_x86_64
+// Forward declare JitShader because shader_jit_x64.h requires ShaderSetup
+// (which uses JitShader) from this file
+class JitShader;
+#endif // ARCHITECTURE_x86_64
+
 struct InputVertex {
     alignas(16) Math::Vec4<float24> attr[16];
 };
@@ -352,6 +358,10 @@ struct ShaderSetup {
     std::array<u32, 1024> program_code;
     std::array<u32, 1024> swizzle_data;
 
+#ifdef ARCHITECTURE_x86_64
+    std::weak_ptr<const JitShader> jit_shader;
+#endif
+
     /**
      * Performs any shader unit setup that only needs to happen once per shader (as opposed to once
      * per vertex, which would happen within the `Run` function).
@@ -363,19 +373,20 @@ struct ShaderSetup {
      * @param state Shader unit state, must be setup per shader and per shader unit
      * @param input Input vertex into the shader
      * @param num_attributes The number of vertex shader attributes
+     * @param config Configuration object for the shader pipeline
      */
-    void Run(UnitState<false>& state, const InputVertex& input, int num_attributes);
+    void Run(UnitState<false>& state, const InputVertex& input, int num_attributes,
+             const Regs::ShaderConfig& config);
 
     /**
      * Produce debug information based on the given shader and input vertex
      * @param input Input vertex into the shader
      * @param num_attributes The number of vertex shader attributes
      * @param config Configuration object for the shader pipeline
-     * @param setup Setup object for the shader pipeline
      * @return Debug information for this shader with regards to the given vertex
      */
     DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes,
-                                     const Regs::ShaderConfig& config, const ShaderSetup& setup);
+                                     const Regs::ShaderConfig& config);
 };
 
 } // namespace Shader

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -355,6 +355,9 @@ struct ShaderSetup {
         }
     }
 
+    int float_regs_counter = 0;
+    u32 uniform_write_buffer[4];
+
     std::array<u32, 1024> program_code;
     std::array<u32, 1024> swizzle_data;
 
@@ -388,6 +391,16 @@ struct ShaderSetup {
     DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes,
                                      const Regs::ShaderConfig& config);
 };
+
+bool SharedGS();
+void WriteUniformBoolReg(bool gs, u32 value);
+void WriteUniformIntReg(bool gs, unsigned index, const Math::Vec4<u8>& values);
+void WriteUniformFloatSetupReg(bool gs, u32 value);
+void WriteUniformFloatReg(bool gs, u32 value);
+void WriteProgramCodeOffset(bool gs, u32 value);
+void WriteProgramCode(bool gs, u32 value);
+void WriteSwizzlePatternsOffset(bool gs, u32 value);
+void WriteSwizzlePatterns(bool gs, u32 value);
 
 } // namespace Shader
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -17,6 +17,7 @@
 #include "common/vector_math.h"
 #include "video_core/pica.h"
 #include "video_core/pica_types.h"
+#include "video_core/primitive_assembly.h"
 
 using nihstro::RegisterType;
 using nihstro::SourceRegister;
@@ -281,6 +282,18 @@ struct UnitState {
     } registers;
     static_assert(std::is_pod<Registers>::value, "Structure is not POD");
 
+    OutputRegisters emit_buffers[3]; // TODO: 3dbrew suggests this only stores the
+                                     // first 7 output registers
+
+    union EmitParameters {
+        u32 raw;
+        BitField<22, 1, u32> winding;
+        BitField<23, 1, u32> primitive_emit;
+        BitField<24, 2, u32> vertex_id;
+    } emit_params;
+
+    PrimitiveAssembler<OutputVertex>::TriangleHandler emit_triangle_callback;
+
     OutputRegisters output_registers;
 
     bool conditional_code[2];
@@ -321,6 +334,10 @@ struct UnitState {
             UNREACHABLE();
             return 0;
         }
+    }
+
+    static size_t EmitParamsOffset() {
+        return offsetof(UnitState, emit_params.raw);
     }
 };
 
@@ -401,6 +418,9 @@ void WriteProgramCodeOffset(bool gs, u32 value);
 void WriteProgramCode(bool gs, u32 value);
 void WriteSwizzlePatternsOffset(bool gs, u32 value);
 void WriteSwizzlePatterns(bool gs, u32 value);
+
+template <bool Debug>
+void HandleEMIT(UnitState<Debug>& state);
 
 } // namespace Shader
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -410,6 +410,8 @@ struct ShaderSetup {
 };
 
 bool SharedGS();
+bool UseGS();
+UnitState<false>& GetShaderUnit(bool gs);
 void WriteUniformBoolReg(bool gs, u32 value);
 void WriteUniformIntReg(bool gs, unsigned index, const Math::Vec4<u8>& values);
 void WriteUniformFloatSetupReg(bool gs, u32 value);

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -640,6 +640,16 @@ void RunInterpreter(const ShaderSetup& setup, UnitState<Debug>& state, unsigned 
                 break;
             }
 
+            case OpCode::Id::EMIT: {
+                Shader::HandleEMIT(state);
+                break;
+            }
+
+            case OpCode::Id::SETEMIT: {
+                state.emit_params.raw = program_code[program_counter];
+                break;
+            }
+
             default:
                 LOG_ERROR(HW_GPU, "Unhandled instruction: 0x%02x (%s): 0x%08x",
                           (int)instr.opcode.Value().EffectiveOpCode(),

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -44,9 +44,9 @@ void RunInterpreter(const ShaderSetup& setup, UnitState<Debug>& state, unsigned 
 
     u32 program_counter = offset;
 
-    const auto& uniforms = g_state.vs.uniforms;
-    const auto& swizzle_data = g_state.vs.swizzle_data;
-    const auto& program_code = g_state.vs.program_code;
+    const auto& uniforms = setup.uniforms;
+    const auto& swizzle_data = setup.swizzle_data;
+    const auto& program_code = setup.program_code;
 
     // Placeholder for invalid inputs
     static float24 dummy_vec4_float24[4];

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -33,70 +33,70 @@ namespace Shader {
 typedef void (JitShader::*JitFunction)(Instruction instr);
 
 const JitFunction instr_table[64] = {
-    &JitShader::Compile_ADD,   // add
-    &JitShader::Compile_DP3,   // dp3
-    &JitShader::Compile_DP4,   // dp4
-    &JitShader::Compile_DPH,   // dph
-    nullptr,                   // unknown
-    &JitShader::Compile_EX2,   // ex2
-    &JitShader::Compile_LG2,   // lg2
-    nullptr,                   // unknown
-    &JitShader::Compile_MUL,   // mul
-    &JitShader::Compile_SGE,   // sge
-    &JitShader::Compile_SLT,   // slt
-    &JitShader::Compile_FLR,   // flr
-    &JitShader::Compile_MAX,   // max
-    &JitShader::Compile_MIN,   // min
-    &JitShader::Compile_RCP,   // rcp
-    &JitShader::Compile_RSQ,   // rsq
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    &JitShader::Compile_MOVA,  // mova
-    &JitShader::Compile_MOV,   // mov
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    &JitShader::Compile_DPH,   // dphi
-    nullptr,                   // unknown
-    &JitShader::Compile_SGE,   // sgei
-    &JitShader::Compile_SLT,   // slti
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    nullptr,                   // unknown
-    &JitShader::Compile_NOP,   // nop
-    &JitShader::Compile_END,   // end
-    nullptr,                   // break
-    &JitShader::Compile_CALL,  // call
-    &JitShader::Compile_CALLC, // callc
-    &JitShader::Compile_CALLU, // callu
-    &JitShader::Compile_IF,    // ifu
-    &JitShader::Compile_IF,    // ifc
-    &JitShader::Compile_LOOP,  // loop
-    nullptr,                   // emit
-    nullptr,                   // sete
-    &JitShader::Compile_JMP,   // jmpc
-    &JitShader::Compile_JMP,   // jmpu
-    &JitShader::Compile_CMP,   // cmp
-    &JitShader::Compile_CMP,   // cmp
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // madi
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
-    &JitShader::Compile_MAD,   // mad
+    &JitShader::Compile_ADD,     // add
+    &JitShader::Compile_DP3,     // dp3
+    &JitShader::Compile_DP4,     // dp4
+    &JitShader::Compile_DPH,     // dph
+    nullptr,                     // unknown
+    &JitShader::Compile_EX2,     // ex2
+    &JitShader::Compile_LG2,     // lg2
+    nullptr,                     // unknown
+    &JitShader::Compile_MUL,     // mul
+    &JitShader::Compile_SGE,     // sge
+    &JitShader::Compile_SLT,     // slt
+    &JitShader::Compile_FLR,     // flr
+    &JitShader::Compile_MAX,     // max
+    &JitShader::Compile_MIN,     // min
+    &JitShader::Compile_RCP,     // rcp
+    &JitShader::Compile_RSQ,     // rsq
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    &JitShader::Compile_MOVA,    // mova
+    &JitShader::Compile_MOV,     // mov
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    &JitShader::Compile_DPH,     // dphi
+    nullptr,                     // unknown
+    &JitShader::Compile_SGE,     // sgei
+    &JitShader::Compile_SLT,     // slti
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    nullptr,                     // unknown
+    &JitShader::Compile_NOP,     // nop
+    &JitShader::Compile_END,     // end
+    nullptr,                     // break
+    &JitShader::Compile_CALL,    // call
+    &JitShader::Compile_CALLC,   // callc
+    &JitShader::Compile_CALLU,   // callu
+    &JitShader::Compile_IF,      // ifu
+    &JitShader::Compile_IF,      // ifc
+    &JitShader::Compile_LOOP,    // loop
+    &JitShader::Compile_EMIT,    // emit
+    &JitShader::Compile_SETEMIT, // setemit
+    &JitShader::Compile_JMP,     // jmpc
+    &JitShader::Compile_JMP,     // jmpu
+    &JitShader::Compile_CMP,     // cmp
+    &JitShader::Compile_CMP,     // cmp
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // madi
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
+    &JitShader::Compile_MAD,     // mad
 };
 
 // The following is used to alias some commonly used registers. Generally, RAX-RDX and XMM0-XMM3 can
@@ -745,6 +745,22 @@ void JitShader::Compile_LOOP(Instruction instr) {
     jnz(l_loop_start);           // Loop if not equal
 
     looping = false;
+}
+
+static void Handle_EMIT(void* param1) {
+    UnitState<false>& state = *static_cast<UnitState<false>*>(param1);
+    Shader::HandleEMIT(state);
+};
+
+void JitShader::Compile_EMIT(Instruction instr) {
+    ABI_PushRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
+    mov(ABI_PARAM1, STATE);
+    CallFarFunction(*this, Handle_EMIT);
+    ABI_PopRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
+}
+
+void JitShader::Compile_SETEMIT(Instruction instr) {
+    mov(dword[STATE + UnitState<false>::EmitParamsOffset()], *(u32*)&instr.setemit);
 }
 
 void JitShader::Compile_JMP(Instruction instr) {

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -63,6 +63,8 @@ public:
     void Compile_CALLU(Instruction instr);
     void Compile_IF(Instruction instr);
     void Compile_LOOP(Instruction instr);
+    void Compile_EMIT(Instruction instr);
+    void Compile_SETEMIT(Instruction instr);
     void Compile_JMP(Instruction instr);
     void Compile_CMP(Instruction instr);
     void Compile_MAD(Instruction instr);

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -38,7 +38,7 @@ public:
         program(&setup, &state, instruction_labels[offset].getAddress());
     }
 
-    void Compile();
+    void Compile(const ShaderSetup& setup);
 
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
@@ -98,6 +98,17 @@ private:
     void Compile_Assert(bool condition, const char* msg);
 
     /**
+     * Get the shader instruction for a given offset in the current shader program
+     * @param offset Offset in the current shader program of the instruction
+     * @return Instruction at the specified offset
+     */
+    Instruction GetShaderInstruction(size_t offset) {
+        Instruction instruction;
+        std::memcpy(&instruction, &setup->program_code[offset], sizeof(Instruction));
+        return instruction;
+    }
+
+    /**
      * Analyzes the entire shader program for `CALL` instructions before emitting any code,
      * identifying the locations where a return needs to be inserted.
      */
@@ -114,6 +125,8 @@ private:
 
     using CompiledShader = void(const void* setup, void* state, const u8* start_addr);
     CompiledShader* program = nullptr;
+
+    const ShaderSetup* setup = nullptr;
 };
 
 } // Shader


### PR DESCRIPTION
This PR includes:
- Geometry shader (EMIT/SETEMIT) in JIT and interpreter
- 4 Emulated shader units with a state for each
- Cleanup of shader code

This PR does _not_ include:
- [A geometry shader debugger (there is a temporary hack in another branch)](https://github.com/JayFoxRox/citra/pull/7)
- A perfect implementation (however, it's enough to get us started)

---

The following is a description of each commit - it might assist you in the review process.
(Don't be scared off, you can also just review without this)

I often ask for seperate issues to fix smaller problems. I could potentially add a solution to this, however the current `master` is usually worse and delaying this PR because of too many smaller issues will probably break it sooner or later and we'll run into a cycle of never being able to merge this.
- [ ] **Make shader code less VS-specific**
  Instead of passing ShaderSetup around it now uses the member variables in function calls. All calls dealing with shaders also take a ShaderConfig parameter now (which is the shader state in the Pica regs) so different config can be passed to invocations of the GS.
  The JitShader needs a forward declaration due to jit_shader being part of shader.h (ShaderSetup now) and shader_jit_x64.h depending on ShaderSetup (shader.h).
  This also introduces a hacky pointer variable called `setup` in the JIT struct as the JIT compilation process requires access to ShaderSetup but I found no way to add it otherwise. The pointer is only valid during compilation and will be `nullptr` otherwise.
- [ ] **Only check for JIT in Setup**
  This should fix #1051. The check wether JIT is enabled has been moved to Setup.
  A weak_ptr is used so a cache clear really destroys all shaders.
  (In the worst case this might run the interpreter if the cache is cleared betwen ::Setup and ::Run until the next setup. I think this is totally fine but others might think it's against the users wish - seperate issue please)
- [ ] **Prepare Pica regs for GS**
  Introduces the registers related to the GS.
- [ ] **Write shader registers in functions**
  If the vsh_com_mode is indicating some shared mode Shader Unit 4 (used for VS or GS) will receive the same uniform / program / swizzle data as Shader Unit 1-3 (used for VS). To make the write-through easier I split the register handlers into seperate functions.
- [ ] **Write GS registers**
  This adds the handlers for the geometry shader register writes which will call the functions from the previous commit to update registers while in GS mode.
- [ ] **Implement EMIT and SETEMIT**
  This implements the 2 geometry shader instructions (but they are not called in this commit because VS don't use them and GS aren't run yet).
  SETEMIT is just a MOV. EMIT will just ABI call to `Shader::HandleEMIT` which then calls a std::function stored per shader unit (this way a VS unit could return errors and debug units could record submitted triangles for display in a debugger).
- [ ] **Implement 4 shader units and geometry shaders**
  `master` always creates a new UnitState for each shader invocation. On hardware each Shader Unit maintains it's own state (for temporary registers, maybe: conditionals, output registers (not writing them is undefined behaviour I heard) and also emit_params - needs testing! seperate issue please)
  To emulate this I create an array of shader_units in the Pica state and implemented a very poor scheduler. Scheduling unit 4 always broke something so this will have to do for now (seperate issue please).

---

This PR was tested with a handful of games. @JohnGodGames also tested some games and I'm not aware of any problems.

I'd also like to apologize to @ds84182 as most of the actual code was stolen from him but I'm not smart enough with git to make his name pop up in the commits he contributed most of. Just trust me when I say that this probably wouldn't be possible without him.
So a massive THANK YOU goes out in his direction.

---

TODO:
- [x] ~~Wait for bunnei's original PR~~
- [x] ~~rebase onto master (currently on bunnei/refactor-shader-jit (april 10th))~~
- [ ] Fix bug with ~1000 errors on first shader upload etc. (com_mode still broken?!)
- [x] ~~cleanup 93affc3~~
- [ ] rename commits to pica naming scheme
- [ ] Finish PR description
- [x] ~~Think of a cool and fancy PR title~~
- [x] ~~Smart pointer for jit_shader and shader cache?~~
