### PR TITLE
Implement buffer-allow registers

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_dec.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_dec.cpp
@@ -422,6 +422,10 @@ ARMDecodeStatus DecodeARMInstruction(u32 instr, s32* idx) {
         n = arm_instruction[i].attribute_value;
         base = 0;
 
+        // 3DS has no VFP3 support
+        if (arm_instruction[i].version == ARMVFP3)
+            continue;
+
         while (n) {
             if (arm_instruction[i].content[base + 1] == 31 && arm_instruction[i].content[base] == 0) {
                 // clrex

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -560,7 +560,7 @@ static u32 vfp_double_ftoui(ARMul_State* state, int sd, int unused, int dm, u32 
     if (vdm.exponent >= 1023 + 32) {
         d = vdm.sign ? 0 : 0xffffffff;
         exceptions = FPSCR_IOC;
-    } else if (vdm.exponent >= 1023 - 1) {
+    } else if (vdm.exponent >= 1023) {
         int shift = 1023 + 63 - vdm.exponent;
         u64 rem, incr = 0;
 
@@ -644,7 +644,7 @@ static u32 vfp_double_ftosi(ARMul_State* state, int sd, int unused, int dm, u32 
         if (vdm.sign)
             d = ~d;
         exceptions |= FPSCR_IOC;
-    } else if (vdm.exponent >= 1023 - 1) {
+    } else if (vdm.exponent >= 1023) {
         int shift = 1023 + 63 - vdm.exponent;	/* 58 */
         u64 rem, incr = 0;
 

--- a/src/video_core/clipper.cpp
+++ b/src/video_core/clipper.cpp
@@ -64,8 +64,6 @@ static void InitScreenCoordinates(OutputVertex& vtx)
     viewport.halfsize_y = float24::FromRaw(regs.viewport_size_y);
     viewport.offset_x   = float24::FromFloat32(static_cast<float>(regs.viewport_corner.x));
     viewport.offset_y   = float24::FromFloat32(static_cast<float>(regs.viewport_corner.y));
-    viewport.zscale     = float24::FromRaw(regs.viewport_depth_range);
-    viewport.offset_z   = float24::FromRaw(regs.viewport_depth_far_plane);
 
     float24 inv_w = float24::FromFloat32(1.f) / vtx.pos.w;
     vtx.color *= inv_w;
@@ -78,7 +76,7 @@ static void InitScreenCoordinates(OutputVertex& vtx)
 
     vtx.screenpos[0] = (vtx.pos.x * inv_w + float24::FromFloat32(1.0)) * viewport.halfsize_x + viewport.offset_x;
     vtx.screenpos[1] = (vtx.pos.y * inv_w + float24::FromFloat32(1.0)) * viewport.halfsize_y + viewport.offset_y;
-    vtx.screenpos[2] = viewport.offset_z + vtx.pos.z * inv_w * viewport.zscale;
+    vtx.screenpos[2] = vtx.pos.z * inv_w;
 }
 
 void ProcessTriangle(const OutputVertex &v0, const OutputVertex &v1, const OutputVertex &v2) {

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -23,6 +23,8 @@
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/shader/shader_interpreter.h"
 
+#include <GL/gl.h>
+
 namespace Pica {
 
 namespace CommandProcessor {
@@ -169,6 +171,13 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (g_debug_context) {
                     g_debug_context->OnEvent(DebugContext::Event::FinishedPrimitiveBatch, nullptr);
                 }
+
+                float depth;
+                uint8_t stencil;
+                glReadPixels(regs.framebuffer.GetWidth() / 2, regs.framebuffer.GetHeight() / 2, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
+                glReadPixels(regs.framebuffer.GetWidth() / 2, regs.framebuffer.GetHeight() / 2, 1, 1, GL_STENCIL_INDEX, GL_UNSIGNED_BYTE, &stencil);
+                printf("Read depth: %f, stencil: 0x%02X\n", depth, stencil);
+
             }
             break;
 

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -591,7 +591,25 @@ struct Regs {
     }
 
     struct {
-        INSERT_PADDING_WORDS(0x6);
+        INSERT_PADDING_WORDS(0x2);
+
+        union {
+            BitField<0, 4, u32> allow_color_read; // Allow read (0 = disable, 0xF = enable)
+        };
+
+        union {
+            BitField<0, 4, u32> allow_color_write; // Allow write (0 = disable, 0xF = enable)
+        };
+
+        union {
+            BitField<0, 1, u32> allow_stencil_read; // Allow stencil read (0 = disable, 1 = enable)
+            BitField<1, 1, u32> allow_depth_read; // Allow depth read (0 = disable, 1 = enable)
+        };
+
+        union {
+            BitField<0, 1, u32> allow_stencil_write; // Allow stencil write (0 = disable, 1 = enable)
+            BitField<1, 1, u32> allow_depth_write; // Allow depth write (0 = disable, 1 = enable)
+        };
 
         DepthFormat depth_format; // TODO: Should be a BitField!
         BitField<16, 3, ColorFormat> color_format;

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -69,7 +69,7 @@ struct Regs {
     INSERT_PADDING_WORDS(0x9);
 
     BitField<0, 24, u32> viewport_depth_range; // float24
-    BitField<0, 24, u32> viewport_depth_far_plane; // float24
+    BitField<0, 24, u32> viewport_depth_near_plane; // float24
 
     BitField<0, 3, u32> vs_output_total;
 
@@ -121,7 +121,20 @@ struct Regs {
         BitField<16, 10, s32> y;
     } viewport_corner;
 
-    INSERT_PADDING_WORDS(0x17);
+    INSERT_PADDING_WORDS(0x1);
+
+    //TODO: early depth
+    INSERT_PADDING_WORDS(0x1);
+
+    INSERT_PADDING_WORDS(0x2);
+
+    enum DepthBuffering : u32 {
+        WBuffering  = 0,
+        ZBuffering  = 1,
+    };
+    BitField< 0, 1, DepthBuffering> depthmap_enable;
+
+    INSERT_PADDING_WORDS(0x12);
 
     struct TextureConfig {
         enum WrapMode : u32 {
@@ -1263,10 +1276,11 @@ ASSERT_REG_POSITION(cull_mode, 0x40);
 ASSERT_REG_POSITION(viewport_size_x, 0x41);
 ASSERT_REG_POSITION(viewport_size_y, 0x43);
 ASSERT_REG_POSITION(viewport_depth_range, 0x4d);
-ASSERT_REG_POSITION(viewport_depth_far_plane, 0x4e);
+ASSERT_REG_POSITION(viewport_depth_near_plane, 0x4e);
 ASSERT_REG_POSITION(vs_output_attributes[0], 0x50);
 ASSERT_REG_POSITION(vs_output_attributes[1], 0x51);
 ASSERT_REG_POSITION(viewport_corner, 0x68);
+ASSERT_REG_POSITION(depthmap_enable, 0x6D);
 ASSERT_REG_POSITION(texture0_enable, 0x80);
 ASSERT_REG_POSITION(texture0, 0x81);
 ASSERT_REG_POSITION(texture0_format, 0x8e);

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -809,11 +809,12 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
 
             auto UpdateStencil = [stencil_test, x, y, &old_stencil](Pica::Regs::StencilAction action) {
                 u8 new_stencil = PerformStencilAction(action, old_stencil, stencil_test.reference_value);
-                SetStencil(x >> 4, y >> 4, (new_stencil & stencil_test.write_mask) | (old_stencil & ~stencil_test.write_mask));
+                if (g_state.regs.framebuffer.allow_stencil_write)
+                    SetStencil(x >> 4, y >> 4, (new_stencil & stencil_test.write_mask) | (old_stencil & ~stencil_test.write_mask));
             };
 
             if (stencil_action_enable) {
-                old_stencil = GetStencil(x >> 4, y >> 4);
+                old_stencil = regs.framebuffer.allow_stencil_read ? GetStencil(x >> 4, y >> 4) : 0;
                 u8 dest = old_stencil & stencil_test.input_mask;
                 u8 ref = stencil_test.reference_value & stencil_test.input_mask;
 
@@ -885,7 +886,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
             u32 z = (u32)(depth * ((1 << num_bits) - 1));
 
             if (output_merger.depth_test_enable) {
-                u32 ref_z = GetDepth(x >> 4, y >> 4);
+                u32 ref_z = regs.framebuffer.allow_depth_read ? GetDepth(x >> 4, y >> 4) : 0;
 
                 bool pass = false;
 
@@ -930,14 +931,14 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 }
             }
 
-            if (output_merger.depth_write_enable)
+            if (regs.framebuffer.allow_depth_write && output_merger.depth_write_enable)
                 SetDepth(x >> 4, y >> 4, z);
 
             // The stencil depth_pass action is executed even if depth testing is disabled
             if (stencil_action_enable)
                 UpdateStencil(stencil_test.action_depth_pass);
 
-            auto dest = GetPixel(x >> 4, y >> 4);
+            auto dest = regs.framebuffer.allow_color_read != 0x0 ? GetPixel(x >> 4, y >> 4) : Math::Vec4<u8>(0,0,0,0);
             Math::Vec4<u8> blend_output = combiner_output;
 
             if (output_merger.alphablend_enable) {
@@ -1155,7 +1156,8 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 output_merger.alpha_enable ? blend_output.a() : dest.a()
             };
 
-            DrawPixel(x >> 4, y >> 4, result);
+            if (regs.framebuffer.allow_color_write != 0x0)
+                DrawPixel(x >> 4, y >> 4, result);
         }
     }
 }

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -858,10 +858,31 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 }
             }
 
+            // interpolated_z = z / w
+            float interpolated_z_over_w = (v0.screenpos[2].ToFloat32() * w0 +
+                                           v1.screenpos[2].ToFloat32() * w1 +
+                                           v2.screenpos[2].ToFloat32() * w2) / wsum;
+
+            // Z-Buffer (z / w * scale + offset)
+            float depth_scale = float24::FromRaw(regs.viewport_depth_range).ToFloat32();
+            float depth_offset = float24::FromRaw(regs.viewport_depth_near_plane).ToFloat32();
+            float depth = interpolated_z_over_w * depth_scale + depth_offset;
+
+            // Potentially switch to W-Buffer
+            if (regs.depthmap_enable == Pica::Regs::DepthBuffering::WBuffering) {
+                float interpolated_w = interpolated_w_inverse.ToFloat32() * wsum;
+
+                // W-Buffer (z * scale + w * offset = (z / w * scale + offset) * w)
+                depth *= interpolated_w;
+
+            }
+
+            // Clamp the result
+            depth = MathUtil::Clamp(depth, 0.0f, 1.0f);
+
+            // Convert float to integer
             unsigned num_bits = Regs::DepthBitsPerPixel(regs.framebuffer.depth_format);
-            u32 z = (u32)((v0.screenpos[2].ToFloat32() * w0 +
-                           v1.screenpos[2].ToFloat32() * w1 +
-                           v2.screenpos[2].ToFloat32() * w2) * ((1 << num_bits) - 1) / wsum);
+            u32 z = (u32)(depth * ((1 << num_bits) - 1));
 
             if (output_merger.depth_test_enable) {
                 u32 ref_z = GetDepth(x >> 4, y >> 4);
@@ -990,6 +1011,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                         return 255 - combiner_output.a();
 
                     case Regs::BlendFactor::DestAlpha:
+                    case Regs::BlendFactor::DestColor:
                         return dest.a();
 
                     case Regs::BlendFactor::OneMinusDestAlpha:

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -247,7 +247,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
 
     // Depth modifiers
     case PICA_REG_INDEX(viewport_depth_range):
-    case PICA_REG_INDEX(viewport_depth_far_plane):
+    case PICA_REG_INDEX(viewport_depth_near_plane):
         SyncDepthModifiers();
         break;
 
@@ -837,7 +837,7 @@ void RasterizerOpenGL::SyncCullMode() {
 
 void RasterizerOpenGL::SyncDepthModifiers() {
     float depth_scale = -Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_range).ToFloat32();
-    float depth_offset = Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_far_plane).ToFloat32() / 2.0f;
+    float depth_offset = Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_near_plane).ToFloat32() / 2.0f;
 
     // TODO: Implement scale modifier
     uniform_block_data.data.depth_offset = depth_offset;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -251,6 +251,11 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncDepthModifiers();
         break;
 
+    // Depth buffering
+    case PICA_REG_INDEX(depthmap_enable):
+        state.draw.shader_dirty = true;
+        break;
+
     // Blending
     case PICA_REG_INDEX(output_merger.alphablend_enable):
         SyncBlendEnabled();
@@ -837,9 +842,9 @@ void RasterizerOpenGL::SyncCullMode() {
 
 void RasterizerOpenGL::SyncDepthModifiers() {
     float depth_scale = -Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_range).ToFloat32();
-    float depth_offset = Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_near_plane).ToFloat32() / 2.0f;
+    float depth_offset = Pica::float24::FromRaw(Pica::g_state.regs.viewport_depth_near_plane).ToFloat32();
 
-    // TODO: Implement scale modifier
+    uniform_block_data.data.depth_scale = depth_scale;
     uniform_block_data.data.depth_offset = depth_offset;
     uniform_block_data.dirty = true;
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -304,6 +304,12 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncColorWriteMask();
         break;
 
+    // Color read mask
+    case PICA_REG_INDEX(framebuffer.allow_color_read):
+        SyncLogicOp();
+        SyncBlendFuncs();
+        break;
+
     // Logic op
     case PICA_REG_INDEX(output_merger.logic_op):
         SyncLogicOp();
@@ -875,10 +881,33 @@ void RasterizerOpenGL::SyncBlendEnabled() {
 
 void RasterizerOpenGL::SyncBlendFuncs() {
     const auto& regs = Pica::g_state.regs;
-    state.blend.src_rgb_func = PicaToGL::BlendFunc(regs.output_merger.alpha_blending.factor_source_rgb);
-    state.blend.dst_rgb_func = PicaToGL::BlendFunc(regs.output_merger.alpha_blending.factor_dest_rgb);
-    state.blend.src_a_func = PicaToGL::BlendFunc(regs.output_merger.alpha_blending.factor_source_a);
-    state.blend.dst_a_func = PicaToGL::BlendFunc(regs.output_merger.alpha_blending.factor_dest_a);
+
+    // This function pretends the destination read was 0x00 if the reads are not allowed
+    auto BlendAllowedFunc = [&](bool dest, Pica::Regs::BlendFactor factor) -> GLenum {
+
+        if (regs.framebuffer.allow_color_read == 0x0) {
+
+            // Destination would only read zero, so we can multiply by ZERO in blend func
+            if (dest)
+                return GL_ZERO;
+
+            if (factor == Pica::Regs::BlendFactor::DestColor ||
+                factor == Pica::Regs::BlendFactor::DestAlpha)
+                return GL_ZERO;
+
+            if (factor == Pica::Regs::BlendFactor::OneMinusDestColor ||
+                factor == Pica::Regs::BlendFactor::OneMinusDestAlpha)
+                return GL_ONE;
+
+        }
+
+        return PicaToGL::BlendFunc(factor);
+    };
+
+    state.blend.src_rgb_func = BlendAllowedFunc(false, regs.output_merger.alpha_blending.factor_source_rgb);
+    state.blend.dst_rgb_func = BlendAllowedFunc(true, regs.output_merger.alpha_blending.factor_dest_rgb);
+    state.blend.src_a_func = BlendAllowedFunc(false, regs.output_merger.alpha_blending.factor_source_a);
+    state.blend.dst_a_func = BlendAllowedFunc(true, regs.output_merger.alpha_blending.factor_dest_a);
 }
 
 void RasterizerOpenGL::SyncBlendColor() {
@@ -898,7 +927,61 @@ void RasterizerOpenGL::SyncAlphaTest() {
 }
 
 void RasterizerOpenGL::SyncLogicOp() {
-    state.logic_op = PicaToGL::LogicOp(Pica::g_state.regs.output_merger.logic_op);
+    const auto& regs = Pica::g_state.regs;
+
+    if (regs.framebuffer.allow_color_read == 0x0) {
+
+        // Pretend that the destination reads always return 0
+        switch (regs.output_merger.logic_op) {
+
+        // Always 0
+        case Pica::Regs::LogicOp::Clear:
+        case Pica::Regs::LogicOp::And:
+        case Pica::Regs::LogicOp::AndInverted:
+            state.logic_op = GL_CLEAR;
+            break;
+
+        // Always s
+        case Pica::Regs::LogicOp::AndReverse:
+        case Pica::Regs::LogicOp::Copy:
+        case Pica::Regs::LogicOp::Or:
+        case Pica::Regs::LogicOp::Xor:
+            state.logic_op = GL_COPY;
+            break;
+
+        // Always 1
+        case Pica::Regs::LogicOp::Set:
+        case Pica::Regs::LogicOp::Invert:
+        case Pica::Regs::LogicOp::Nand:
+        case Pica::Regs::LogicOp::OrReverse:
+            state.logic_op = GL_SET;
+            break;
+
+        // Always ~s
+        case Pica::Regs::LogicOp::CopyInverted:
+        case Pica::Regs::LogicOp::Nor:
+        case Pica::Regs::LogicOp::Equiv:
+        case Pica::Regs::LogicOp::OrInverted:
+            state.logic_op = GL_COPY_INVERTED;
+            break;
+
+        // FIXME: Decide for one of those:
+        //a. NoOp means reading zero, writing back zero
+        //b. NoOp means not touching the framebuffer
+        case Pica::Regs::LogicOp::NoOp:
+            state.logic_op = GL_CLEAR; // a
+            state.logic_op = GL_NOOP; // b
+            break;
+
+        default:
+            LOG_CRITICAL(Render_OpenGL, "Unknown logic op %d", regs.output_merger.logic_op);
+            UNREACHABLE();
+            break;
+        }
+
+    } else {
+        state.logic_op = PicaToGL::LogicOp(regs.output_merger.logic_op);
+    }
 }
 
 void RasterizerOpenGL::SyncColorWriteMask() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -35,6 +35,8 @@ struct PicaShaderConfig {
         PicaShaderConfig res;
         const auto& regs = Pica::g_state.regs;
 
+        res.depthmap_enable = regs.depthmap_enable;
+
         res.alpha_test_func = regs.output_merger.alpha_test.enable ?
             regs.output_merger.alpha_test.func.Value() : Pica::Regs::CompareFunc::Always;
 
@@ -140,6 +142,8 @@ struct PicaShaderConfig {
     bool operator ==(const PicaShaderConfig& o) const {
         return std::memcmp(this, &o, sizeof(PicaShaderConfig)) == 0;
     };
+
+    Pica::Regs::DepthBuffering depthmap_enable = Pica::Regs::DepthBuffering::WBuffering;
 
     Pica::Regs::CompareFunc alpha_test_func = Pica::Regs::CompareFunc::Never;
     std::array<Pica::Regs::TevStageConfig, 6> tev_stages = {};
@@ -303,6 +307,7 @@ private:
         GLvec4 const_color[6];
         GLvec4 tev_combiner_buffer_color;
         GLint alphatest_ref;
+        GLfloat depth_scale;
         GLfloat depth_offset;
         alignas(16) GLvec3 lighting_global_ambient;
         LightSrc light_src[8];

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -349,6 +349,15 @@ private:
     /// Syncs the logic op states to match the PICA register
     void SyncLogicOp();
 
+    /// Syncs the color write mask to match the PICA register
+    void SyncColorWriteMask();
+
+    /// Syncs the stencil write mask to match the PICA register
+    void SyncStencilWriteMask();
+
+    /// Syncs the depth write mask to match the PICA register
+    void SyncDepthWriteMask();
+
     /// Syncs the stencil test states to match the PICA register
     void SyncStencilTest();
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -525,6 +525,7 @@ layout (std140) uniform shader_data {
     vec4 const_color[NUM_TEV_STAGES];
     vec4 tev_combiner_buffer_color;
     int alphatest_ref;
+    float depth_scale;
     float depth_offset;
     vec3 lighting_global_ambient;
     LightSrc light_src[NUM_LIGHTS];
@@ -566,7 +567,15 @@ vec4 secondary_fragment_color = vec4(0.0);
     }
 
     out += "color = last_tex_env_out;\n";
-    out += "gl_FragDepth = gl_FragCoord.z + depth_offset;\n}";
+
+    out += "float z_over_w = gl_FragCoord.z * 2.0 - 1.0;\n";
+    out += "float depth = z_over_w * depth_scale + depth_offset;\n";
+    if (config.depthmap_enable == Pica::Regs::DepthBuffering::WBuffering) {
+        out += "depth /= gl_FragCoord.w;\n";
+    }
+    out += "gl_FragDepth = depth;\n";
+
+    out += "}";
 
     return out;
 }

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -155,6 +155,30 @@ inline GLenum CompareFunc(Pica::Regs::CompareFunc func) {
     return compare_func_table[(unsigned)func];
 }
 
+/// Pretend we compare 'x FUNC x'
+inline GLenum CompareXToXFunc(Pica::Regs::CompareFunc func) {
+    static const GLenum compare_func_table[] = {
+        GL_NEVER,    // CompareFunc::Never
+        GL_ALWAYS,   // CompareFunc::Always
+        GL_ALWAYS,   // CompareFunc::Equal
+        GL_NEVER,    // CompareFunc::NotEqual
+        GL_NEVER,    // CompareFunc::LessThan
+        GL_ALWAYS,   // CompareFunc::LessThanOrEqual
+        GL_NEVER,    // CompareFunc::GreaterThan
+        GL_ALWAYS,   // CompareFunc::GreaterThanOrEqual
+    };
+
+    // Range check table for input
+    if (static_cast<size_t>(func) >= ARRAY_SIZE(compare_func_table)) {
+        LOG_CRITICAL(Render_OpenGL, "Unknown compare function %d", func);
+        UNREACHABLE();
+
+        return GL_ALWAYS;
+    }
+
+    return compare_func_table[(unsigned)func];
+}
+
 /// Pretend we compare 'x FUNC 0' (unsigned)
 inline GLenum CompareXToZeroFunc(Pica::Regs::CompareFunc func) {
     static const GLenum compare_func_table[] = {

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -155,6 +155,30 @@ inline GLenum CompareFunc(Pica::Regs::CompareFunc func) {
     return compare_func_table[(unsigned)func];
 }
 
+/// Pretend we compare 'x FUNC 0' (unsigned)
+inline GLenum CompareXToZeroFunc(Pica::Regs::CompareFunc func) {
+    static const GLenum compare_func_table[] = {
+        GL_NEVER,    // CompareFunc::Never
+        GL_ALWAYS,   // CompareFunc::Always
+        GL_EQUAL,    // CompareFunc::Equal
+        GL_NOTEQUAL, // CompareFunc::NotEqual
+        GL_NEVER,    // CompareFunc::LessThan
+        GL_LEQUAL,   // CompareFunc::LessThanOrEqual
+        GL_GREATER,  // CompareFunc::GreaterThan
+        GL_ALWAYS,   // CompareFunc::GreaterThanOrEqual
+    };
+
+    // Range check table for input
+    if (static_cast<size_t>(func) >= ARRAY_SIZE(compare_func_table)) {
+        LOG_CRITICAL(Render_OpenGL, "Unknown compare function %d", func);
+        UNREACHABLE();
+
+        return GL_ALWAYS;
+    }
+
+    return compare_func_table[(unsigned)func];
+}
+
 inline GLenum StencilOp(Pica::Regs::StencilAction action) {
     static const GLenum stencil_op_table[] = {
         GL_KEEP,        // StencilAction::Keep


### PR DESCRIPTION
This PR implements the "allow"-registers which are probably used for powergating (as suggested by @yuriks).
- Some games such as Tappingo still depend on them for disabling depth/stencil writes.

I've chosen the name "allow" myself and I'd be happy to change it to something more fitting.
Essentially those are read/write-enable registers for the buffers.
While the RGBA register field is 4 bits it will still control all channels at once, it's not a bitmask.
Stencil and depth fields are 1 bit each. They also act as a boolean to allow buffer access.

Testing has shown that disallowed color reads will return zero (per channel) to blend ops.

This PR implements this fully in the SW-Rasterizer.

As OpenGL is not able to disable framebuffer reads a giant kludge had to be put in place.
Color read operations (LogicOp and Blending) parameters will be modified to emulate 0x00-reads from the color buffer.

For depth operations the depth test is modified. If the result of the test is known to be constant the depth function is patched so the 0x00-read is emulated.
For stencil tests/operations this is somewhat more complex but works the same way as for depth tests.

If the result for depth and stencil is not static there is a [LOG_CRITICAL and UNIMPLEMENTED]//FIXME: link will be hit. Unless there is a GL extension for this we can't do much about it (There is slight bit of hope left in one specific case. This is outlined in the source code //FIXME: Link).
That being said, the conditions for this to happen are ridiculous.

---

This PR was tested [using a HW-Test](https://github.com/JayFoxRox/3ds-tests/tree/master/buffer-allow) ([Results](https://docs.google.com/spreadsheets/d/113T3Grv5HXEBrXbtdSjFQXuXmb0IO7gETu55ka7djNA/edit#gid=0)).
There are no known regressions while this fixes some games.

Note that for disallowed color-read **LogicOp was not tested** and **only one blend mode was tested**. More tests for this would be nice.

However, this is a rarely used feature so we could also just review code and say: ship it!
(logic ops are very rare, disallowed buffer reads probably even less popular and blending and doing logic ops on those disallowed buffers probably never happens with a properly written SDK)

Also worth noting that most GPUs don't allow write without without read so maybe this even produces undefined behaviour on a real 3DS under some circumstances.

(I'd like to thank @JohnGodGames for testing)

---

TODO:
- ~~Split into read-allow branch~~
- Reflect new findings about depth-stencil sharing the same access mask
- Rebase to master (currently on printf-fix+w-buffer stuff)
- ~~hw-renderer color: Implement the allow bits for logic ops and blending~~
- hw-renderer depth/stencil: LOG_ERROR if writes are enabled but reads aren't +  handle the writemask
- ~~squash fixups~~
- Fix PR description
