### PR TITLE
Implement buffer-write allow registers

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -578,7 +578,17 @@ struct Regs {
     }
 
     struct {
-        INSERT_PADDING_WORDS(0x6);
+        INSERT_PADDING_WORDS(0x3);
+
+        union {
+            BitField<0, 4, u32> allow_color_write; // 0 = disable, else enable
+        };
+
+        INSERT_PADDING_WORDS(0x1);
+
+        union {
+            BitField<0, 2, u32> allow_depth_stencil_write; // 0 = disable, else enable
+        };
 
         DepthFormat depth_format; // TODO: Should be a BitField!
         BitField<16, 3, ColorFormat> color_format;

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -809,7 +809,8 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
 
             auto UpdateStencil = [stencil_test, x, y, &old_stencil](Pica::Regs::StencilAction action) {
                 u8 new_stencil = PerformStencilAction(action, old_stencil, stencil_test.reference_value);
-                SetStencil(x >> 4, y >> 4, (new_stencil & stencil_test.write_mask) | (old_stencil & ~stencil_test.write_mask));
+                if (g_state.regs.framebuffer.allow_depth_stencil_write != 0)
+                    SetStencil(x >> 4, y >> 4, (new_stencil & stencil_test.write_mask) | (old_stencil & ~stencil_test.write_mask));
             };
 
             if (stencil_action_enable) {
@@ -909,7 +910,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 }
             }
 
-            if (output_merger.depth_write_enable)
+            if (regs.framebuffer.allow_depth_stencil_write != 0 && output_merger.depth_write_enable)
                 SetDepth(x >> 4, y >> 4, z);
 
             // The stencil depth_pass action is executed even if depth testing is disabled
@@ -1133,7 +1134,8 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 output_merger.alpha_enable ? blend_output.a() : dest.a()
             };
 
-            DrawPixel(x >> 4, y >> 4, result);
+            if (regs.framebuffer.allow_color_write != 0)
+                DrawPixel(x >> 4, y >> 4, result);
         }
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -269,6 +269,9 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         break;
 
     // Stencil test
+    case PICA_REG_INDEX(framebuffer.depth_format):
+        SyncStencilTest();
+        break;
     case PICA_REG_INDEX(output_merger.stencil_test.raw_func):
     case PICA_REG_INDEX(output_merger.stencil_test.raw_op):
         SyncStencilTest();

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -153,6 +153,9 @@ void RasterizerOpenGL::Reset() {
     SyncLogicOp();
     SyncStencilTest();
     SyncDepthTest();
+    SyncColorWriteMask();
+    SyncStencilWriteMask();
+    SyncDepthWriteMask();
 
     SetShader();
 
@@ -275,11 +278,14 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     case PICA_REG_INDEX(output_merger.stencil_test.raw_func):
     case PICA_REG_INDEX(output_merger.stencil_test.raw_op):
         SyncStencilTest();
+        SyncStencilWriteMask();
         break;
 
     // Depth test
     case PICA_REG_INDEX(output_merger.depth_test_enable):
         SyncDepthTest();
+        SyncDepthWriteMask();
+        SyncColorWriteMask();
         break;
 
     // Logic op
@@ -879,13 +885,30 @@ void RasterizerOpenGL::SyncLogicOp() {
     state.logic_op = PicaToGL::LogicOp(Pica::g_state.regs.output_merger.logic_op);
 }
 
+void RasterizerOpenGL::SyncColorWriteMask() {
+    const auto& regs = Pica::g_state.regs;
+    state.color_mask.red_enabled = regs.output_merger.red_enable;
+    state.color_mask.green_enabled = regs.output_merger.green_enable;
+    state.color_mask.blue_enabled = regs.output_merger.blue_enable;
+    state.color_mask.alpha_enabled = regs.output_merger.alpha_enable;
+}
+
+void RasterizerOpenGL::SyncStencilWriteMask() {
+    const auto& regs = Pica::g_state.regs;
+    state.stencil.write_mask = regs.output_merger.stencil_test.write_mask;
+}
+
+void RasterizerOpenGL::SyncDepthWriteMask() {
+    const auto& regs = Pica::g_state.regs;
+    state.depth.write_mask = regs.output_merger.depth_write_enable ? GL_TRUE : GL_FALSE;
+}
+
 void RasterizerOpenGL::SyncStencilTest() {
     const auto& regs = Pica::g_state.regs;
     state.stencil.test_enabled = regs.output_merger.stencil_test.enable && regs.framebuffer.depth_format == Pica::Regs::DepthFormat::D24S8;
     state.stencil.test_func = PicaToGL::CompareFunc(regs.output_merger.stencil_test.func);
     state.stencil.test_ref = regs.output_merger.stencil_test.reference_value;
     state.stencil.test_mask = regs.output_merger.stencil_test.input_mask;
-    state.stencil.write_mask = regs.output_merger.stencil_test.write_mask;
     state.stencil.action_stencil_fail = PicaToGL::StencilOp(regs.output_merger.stencil_test.action_stencil_fail);
     state.stencil.action_depth_fail = PicaToGL::StencilOp(regs.output_merger.stencil_test.action_depth_fail);
     state.stencil.action_depth_pass = PicaToGL::StencilOp(regs.output_merger.stencil_test.action_depth_pass);
@@ -897,11 +920,6 @@ void RasterizerOpenGL::SyncDepthTest() {
                                regs.output_merger.depth_write_enable == 1;
     state.depth.test_func = regs.output_merger.depth_test_enable == 1 ?
                             PicaToGL::CompareFunc(regs.output_merger.depth_test_func) : GL_ALWAYS;
-    state.color_mask.red_enabled = regs.output_merger.red_enable;
-    state.color_mask.green_enabled = regs.output_merger.green_enable;
-    state.color_mask.blue_enabled = regs.output_merger.blue_enable;
-    state.color_mask.alpha_enabled = regs.output_merger.alpha_enable;
-    state.depth.write_mask = regs.output_merger.depth_write_enable ? GL_TRUE : GL_FALSE;
 }
 
 void RasterizerOpenGL::SyncCombinerColor() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -344,6 +344,15 @@ private:
     /// Syncs the logic op states to match the PICA register
     void SyncLogicOp();
 
+    /// Syncs the color write mask to match the PICA register
+    void SyncColorWriteMask();
+
+    /// Syncs the stencil write mask to match the PICA register
+    void SyncStencilWriteMask();
+
+    /// Syncs the depth write mask to match the PICA register
+    void SyncDepthWriteMask();
+
     /// Syncs the stencil test states to match the PICA register
     void SyncStencilTest();
 


### PR DESCRIPTION
This PR implements 2 of the 4 "allow"-registers which are probably used for powergating (as suggested by @yuriks).
- Some games such as Tappingo still depend on them for disabling depth/stencil writes.

I've chosen the name "allow" myself and I'd be happy to change it to something more fitting.
Essentially those are read/write-enable registers for the buffers.
I use the term "buffer" when it refers to color-, depth- and/or stencil-buffer.

While the RGBA register field is 4 bits it will still control all channels at once, it's not a bitmask.
Depth and stencil share 2 bit. It also controls access to both buffers at once and is not a bitmask.
I did not yet test wether there are more bits which are tested in either of those registers.

This PR implements the write-permission fully in the SW-Rasterizer and the HW-Renderer.
The read-permission will be handled in a seperate PR because the implementation would be somewhat more tricky.

This should fix most of the bugs caused by #1462 .

There is also another commit which fixes a bug which is also present in `master` where the GL stencil test could run out of sync with the Pica stencil test:
The stencil test sync function also checks wether the current Pica framebuffer has a stencil buffer.
The call to the sync function was missing in case the framebuffer is changed after stencil testing was configured (Potentially causing GL to enable stencil with no stencil buffer available - I'm not sure if this could cause problems).

---

This PR was tested [using a HW-Test](https://github.com/JayFoxRox/3ds-tests/tree/master/buffer-allow) ([Results](https://docs.google.com/spreadsheets/d/113T3Grv5HXEBrXbtdSjFQXuXmb0IO7gETu55ka7djNA/edit#gid=0)).
There are no known regressions while this fixes some games.

(I'd like to thank @JohnGodGames for testing)
