### PR TITLE
Implement buffer-read allow registers 

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -648,13 +648,19 @@ struct Regs {
     }
 
     struct FramebufferConfig {
-        INSERT_PADDING_WORDS(0x3);
+        INSERT_PADDING_WORDS(0x2);
+
+        union {
+            BitField<0, 4, u32> allow_color_read; // 0 = disable, else enable
+        };
 
         union {
             BitField<0, 4, u32> allow_color_write; // 0 = disable, else enable
         };
 
-        INSERT_PADDING_WORDS(0x1);
+        union {
+            BitField<0, 2, u32> allow_depth_stencil_read; // 0 = disable, else enable
+        };
 
         union {
             BitField<0, 2, u32> allow_depth_stencil_write; // 0 = disable, else enable

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -963,7 +963,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0, const Shader
             };
 
             if (stencil_action_enable) {
-                old_stencil = GetStencil(x >> 4, y >> 4);
+                old_stencil = (regs.framebuffer.allow_depth_stencil_read != 0) ? GetStencil(x >> 4, y >> 4) : 0;
                 u8 dest = old_stencil & stencil_test.input_mask;
                 u8 ref = stencil_test.reference_value & stencil_test.input_mask;
 
@@ -1013,7 +1013,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0, const Shader
             u32 z = (u32)(depth * ((1 << num_bits) - 1));
 
             if (output_merger.depth_test_enable) {
-                u32 ref_z = GetDepth(x >> 4, y >> 4);
+                u32 ref_z = (regs.framebuffer.allow_depth_stencil_read != 0) ? GetDepth(x >> 4, y >> 4) : 0;
 
                 bool pass = false;
 
@@ -1065,7 +1065,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0, const Shader
             if (stencil_action_enable)
                 UpdateStencil(stencil_test.action_depth_pass);
 
-            auto dest = GetPixel(x >> 4, y >> 4);
+            auto dest = (regs.framebuffer.allow_color_read != 0) ? GetPixel(x >> 4, y >> 4) : Math::Vec4<u8>(0,0,0,0);
             Math::Vec4<u8> blend_output = combiner_output;
 
             if (output_merger.alphablend_enable) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -125,8 +125,8 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     SyncBlendFuncs();
     SyncBlendColor();
     SyncLogicOp();
-    SyncStencilTest();
     SyncDepthTest();
+    SyncStencilTest();
     SyncColorWriteMask();
     SyncStencilWriteMask();
     SyncDepthWriteMask();
@@ -374,6 +374,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     // (Pica depth test function register also contains a depth and color write mask)
     case PICA_REG_INDEX(output_merger.depth_test_enable):
         SyncDepthTest();
+        SyncStencilTest();
         SyncDepthWriteMask();
         SyncColorWriteMask();
         break;
@@ -400,6 +401,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     // Stencil and depth read mask
     case PICA_REG_INDEX(framebuffer.allow_depth_stencil_read):
         SyncDepthTest();
+        SyncStencilTest();
         break;
 
     // Scissor test
@@ -1318,21 +1320,124 @@ void RasterizerOpenGL::SyncDepthWriteMask() {
             : GL_FALSE;
 }
 
+// Depends on the correct GL DepthTest state!
 void RasterizerOpenGL::SyncStencilTest() {
     const auto& regs = Pica::g_state.regs;
-    state.stencil.test_enabled = regs.output_merger.stencil_test.enable &&
+    const auto& stencil_test = regs.output_merger.stencil_test;
+
+    state.stencil.test_enabled = stencil_test.enable &&
                                  regs.framebuffer.depth_format == Pica::Regs::DepthFormat::D24S8;
-    state.stencil.test_func = PicaToGL::CompareFunc(regs.output_merger.stencil_test.func);
-    state.stencil.test_ref = regs.output_merger.stencil_test.reference_value;
-    state.stencil.test_mask = regs.output_merger.stencil_test.input_mask;
-    state.stencil.action_stencil_fail =
-        PicaToGL::StencilOp(regs.output_merger.stencil_test.action_stencil_fail);
-    state.stencil.action_depth_fail =
-        PicaToGL::StencilOp(regs.output_merger.stencil_test.action_depth_fail);
-    state.stencil.action_depth_pass =
-        PicaToGL::StencilOp(regs.output_merger.stencil_test.action_depth_pass);
+
+    if (state.stencil.test_enabled) {
+        if (!regs.framebuffer.allow_depth_stencil_read) {
+
+            // All stencil reads must be emulated as 0x00
+
+            u8 masked_ref = (stencil_test.reference_value & stencil_test.input_mask);
+
+            if (masked_ref == 0x00) {
+                // x = 0x00
+                state.stencil.test_func = PicaToGL::CompareXToXFunc(stencil_test.func);
+            } else {
+                // x = masked stencil ref
+                state.stencil.test_func = PicaToGL::CompareXToZeroFunc(stencil_test.func);
+            }
+
+            //FIXME: check if writeback is possible, otherwise this is useless
+            if (true) {
+
+                // We need a stencil read if we can't decide the stencil test staticly
+                bool needs_stencil_read = (state.stencil.test_func != GL_NEVER &&
+                                           state.stencil.test_func != GL_ALWAYS);
+
+                //TODO: In rare cases the stencil test doesn't depend on the masked ref ('Never'
+                //      and 'Always') and only 1 specific value for the stencil op writes is
+                //      necessary. In those cases one could set the ref and ref-mask to the
+                //      required value.
+                //FIXME: Return value instead..?
+                auto StencilAllowedOp = [&](Pica::Regs::StencilAction action) -> GLenum {
+
+                    switch (action) {
+
+                    // FIXME: Decide for one of those:
+                    //a. Keeping the framebuffer value means reading zero, writing back zero
+                    //b. Keeping the framebuffer value means not touching it
+                    case Pica::Regs::StencilAction::Keep:
+                        return GL_ZERO; // a
+                        return GL_KEEP; // b
+
+                    // Always 0x01, requires 0x01 in masked_ref to work
+                    case Pica::Regs::StencilAction::Increment:
+                    case Pica::Regs::StencilAction::IncrementWrap:
+                        if (masked_ref != 0x01) {
+                            needs_stencil_read = true;
+                        }
+                        return GL_REPLACE;
+
+                    // Always 0xFF, requires 0xFF in masked_ref to work
+                    case Pica::Regs::StencilAction::Invert:
+                    case Pica::Regs::StencilAction::DecrementWrap:
+                        if (masked_ref != 0xFF) {
+                            needs_stencil_read = true;
+                        }
+                        return GL_REPLACE;
+
+                    // Always masked ref
+                    case Pica::Regs::StencilAction::Replace:
+                        return GL_REPLACE;
+
+                    // Always 0x00
+                    case Pica::Regs::StencilAction::Zero:
+                    case Pica::Regs::StencilAction::Decrement:
+                        return GL_ZERO;
+
+                    default:
+                        LOG_CRITICAL(Render_OpenGL, "Unknown stencil action %x", (int)action);
+                        UNIMPLEMENTED();
+                        return GL_KEEP;
+                    }
+
+                };
+
+                // If the stencil test can fail we have to check the stencil op
+                if (state.depth.test_func != GL_ALWAYS) {
+                    state.stencil.action_stencil_fail =
+                        StencilAllowedOp(stencil_test.action_stencil_fail);
+                }
+
+                // If the depth test can pass we have to check the stencil op
+                if (state.depth.test_func != GL_NEVER) {
+                    state.stencil.action_depth_fail =
+                        StencilAllowedOp(stencil_test.action_depth_pass);
+                }
+
+                // If the depth test can fail we have to check the stencil op
+                if (state.depth.test_func != GL_ALWAYS) {
+                    state.stencil.action_depth_pass =
+                        StencilAllowedOp(stencil_test.action_depth_fail);
+                }
+
+                // Now check if we support this mode
+                if (needs_stencil_read) {
+                    LOG_CRITICAL(Render_OpenGL, "Can't emulate disabled read from stencil yet");
+                    UNIMPLEMENTED();
+                }
+
+            }
+
+        } else {
+            state.stencil.test_func = PicaToGL::CompareFunc(stencil_test.func);
+            state.stencil.test_ref = stencil_test.reference_value;
+            state.stencil.test_mask = stencil_test.input_mask;
+            state.stencil.action_stencil_fail =
+                PicaToGL::StencilOp(stencil_test.action_stencil_fail);
+            state.stencil.action_depth_fail = PicaToGL::StencilOp(stencil_test.action_depth_fail);
+            state.stencil.action_depth_pass = PicaToGL::StencilOp(stencil_test.action_depth_pass);
+        }
+    }
 }
 
+// Always call SyncStencilTest after this returns!
 void RasterizerOpenGL::SyncDepthTest() {
     const auto& regs = Pica::g_state.regs;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -397,6 +397,11 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncBlendFuncs();
         break;
 
+    // Stencil and depth read mask
+    case PICA_REG_INDEX(framebuffer.allow_depth_stencil_read):
+        SyncDepthTest();
+        break;
+
     // Scissor test
     case PICA_REG_INDEX(scissor_test.mode):
         shader_dirty = true;
@@ -1330,11 +1335,30 @@ void RasterizerOpenGL::SyncStencilTest() {
 
 void RasterizerOpenGL::SyncDepthTest() {
     const auto& regs = Pica::g_state.regs;
-    state.depth.test_enabled =
-        regs.output_merger.depth_test_enable == 1 || regs.output_merger.depth_write_enable == 1;
-    state.depth.test_func = regs.output_merger.depth_test_enable == 1
-                                ? PicaToGL::CompareFunc(regs.output_merger.depth_test_func)
-                                : GL_ALWAYS;
+
+    // Enable depth test so depth writes can still occur
+    state.depth.test_enabled = GL_TRUE;
+
+    if (!regs.output_merger.depth_test_enable) {
+        state.depth.test_func = GL_ALWAYS;
+    } else {
+
+        if (!regs.framebuffer.allow_depth_stencil_read) {
+
+            // If reads are not allowed we have to patch the depth test accordingly
+            state.depth.test_func = PicaToGL::CompareXToZeroFunc(regs.output_merger.depth_test_func);
+
+            // Check if the result is known at this point, if not it depends on the framebuffer really being zero
+            if (state.depth.test_func != GL_NEVER && state.depth.test_func != GL_ALWAYS) {
+                LOG_CRITICAL(Render_OpenGL, "Can't emulate disabled read on depth yet");
+                UNIMPLEMENTED();
+            }
+
+        } else {
+            state.depth.test_func = PicaToGL::CompareFunc(regs.output_merger.depth_test_func);
+        }
+
+    }
 }
 
 void RasterizerOpenGL::SyncCombinerColor() {

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -180,6 +180,30 @@ inline GLenum CompareFunc(Pica::Regs::CompareFunc func) {
     return compare_func_table[(unsigned)func];
 }
 
+/// Pretend we compare 'x FUNC 0' (unsigned)
+inline GLenum CompareXToZeroFunc(Pica::Regs::CompareFunc func) {
+    static const GLenum compare_func_table[] = {
+        GL_NEVER,    // CompareFunc::Never
+        GL_ALWAYS,   // CompareFunc::Always
+        GL_EQUAL,    // CompareFunc::Equal
+        GL_NOTEQUAL, // CompareFunc::NotEqual
+        GL_NEVER,    // CompareFunc::LessThan
+        GL_LEQUAL,   // CompareFunc::LessThanOrEqual
+        GL_GREATER,  // CompareFunc::GreaterThan
+        GL_ALWAYS,   // CompareFunc::GreaterThanOrEqual
+    };
+
+    // Range check table for input
+    if (static_cast<size_t>(func) >= ARRAY_SIZE(compare_func_table)) {
+        LOG_CRITICAL(Render_OpenGL, "Unknown compare function %d", func);
+        UNREACHABLE();
+
+        return GL_ALWAYS;
+    }
+
+    return compare_func_table[(unsigned)func];
+}
+
 inline GLenum StencilOp(Pica::Regs::StencilAction action) {
     static const GLenum stencil_op_table[] = {
         GL_KEEP,      // StencilAction::Keep

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -180,6 +180,30 @@ inline GLenum CompareFunc(Pica::Regs::CompareFunc func) {
     return compare_func_table[(unsigned)func];
 }
 
+/// Pretend we compare 'x FUNC x'
+inline GLenum CompareXToXFunc(Pica::Regs::CompareFunc func) {
+    static const GLenum compare_func_table[] = {
+        GL_NEVER,    // CompareFunc::Never
+        GL_ALWAYS,   // CompareFunc::Always
+        GL_ALWAYS,   // CompareFunc::Equal
+        GL_NEVER,    // CompareFunc::NotEqual
+        GL_NEVER,    // CompareFunc::LessThan
+        GL_ALWAYS,   // CompareFunc::LessThanOrEqual
+        GL_NEVER,    // CompareFunc::GreaterThan
+        GL_ALWAYS,   // CompareFunc::GreaterThanOrEqual
+    };
+
+    // Range check table for input
+    if (static_cast<size_t>(func) >= ARRAY_SIZE(compare_func_table)) {
+        LOG_CRITICAL(Render_OpenGL, "Unknown compare function %d", func);
+        UNREACHABLE();
+
+        return GL_ALWAYS;
+    }
+
+    return compare_func_table[(unsigned)func];
+}
+
 /// Pretend we compare 'x FUNC 0' (unsigned)
 inline GLenum CompareXToZeroFunc(Pica::Regs::CompareFunc func) {
     static const GLenum compare_func_table[] = {


### PR DESCRIPTION
This PR implements the remaining 2 of the 4 "allow"-registers which are probably used for powergating (as suggested by @yuriks).
- While #1624 was actually useful this is just for completeness. I'm not aware of any game using this.

Testing has shown that disallowed reads will return zero. This PR implements this fully in the SW-Rasterizer.

As OpenGL is not able to disable framebuffer reads a giant kludge had to be put in place.
Color read operations (LogicOp and Blending) parameters will be modified to emulate 0x00-reads from the color buffer.

For depth operations the depth test is modified. If the result of the test is known to be constant the depth function is patched so the 0x00-read is emulated.
For stencil tests/operations this is somewhat more complex but works the same way as for depth tests.

If the result for depth and stencil is not static there is a [LOG_CRITICAL and UNIMPLEMENTED]//FIXME: link will be hit. Unless there is a GL extension for this we can't do much about it (A couple of cases can still be hacked further to fake more results, but that gets really hacky then).
That being said, the conditions for most of this to happen are ridiculous.

---

This PR was tested [using a HW-Test](https://github.com/JayFoxRox/3ds-tests/tree/master/buffer-allow) ([Results](https://docs.google.com/spreadsheets/d/113T3Grv5HXEBrXbtdSjFQXuXmb0IO7gETu55ka7djNA/edit#gid=0)).
There are no known regressions.

Note that for disallowed color-read **LogicOp was not tested** and **only one blend mode was tested**. More tests for this would be nice.

However, this is a rarely used feature so we could also just review code and say: ship it!
(logic ops are very rare, disallowed buffer reads probably even less popular and blending and doing logic ops on those disallowed buffers probably never happens with a properly written SDK)

Also worth noting that most GPUs don't allow write without without read so maybe this even produces undefined behaviour on a real 3DS under some circumstances.

(I'd like to thank @JohnGodGames for testing)

---

TODO:
- Rebase to master (currently on printf-fix+w-buffer stuff)
- ~~Reflect new findings about depth-stencil sharing the same access mask~~
- ~~hw-renderer color: Implement the allow bits for logic ops and blending~~
- hw-renderer depth/stencil: LOG_ERROR if writes are enabled but reads aren't +  handle the writemask
- merge depth and stencil test sync function?
- ~~squash fixups~~
- Fix PR description
