### PR TITLE
Refactor Tev stage dumper

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -708,12 +708,16 @@ void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig,6>& stages)
         const auto& tev_stage = stages[index];
 
         static const std::map<Source, std::string> source_map = {
-            { Source::PrimaryColor, "PrimaryColor" },
-            { Source::Texture0, "Texture0" },
-            { Source::Texture1, "Texture1" },
-            { Source::Texture2, "Texture2" },
-            { Source::Constant, "Constant" },
-            { Source::Previous, "Previous" },
+            { Source::PrimaryColor,           "PrimaryColor" },
+            { Source::PrimaryFragmentColor,   "PrimaryFragmentColor" },
+            { Source::SecondaryFragmentColor, "SecondaryFragmentColor" },
+            { Source::Texture0,               "Texture0" },
+            { Source::Texture1,               "Texture1" },
+            { Source::Texture2,               "Texture2" },
+            { Source::Texture3,               "Texture3" },
+            { Source::PreviousBuffer,         "PreviousBuffer" },
+            { Source::Constant,               "Constant" },
+            { Source::Previous,               "Previous" },
         };
 
         static const std::map<ColorModifier, std::string> color_modifier_map = {
@@ -722,14 +726,19 @@ void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig,6>& stages)
         };
         static const std::map<AlphaModifier, std::string> alpha_modifier_map = {
             { AlphaModifier::SourceAlpha, "%source.a" },
-            { AlphaModifier::OneMinusSourceAlpha, "(255 - %source.a)" },
+            { AlphaModifier::OneMinusSourceAlpha, "(1.0 - %source.a)" },
         };
 
         static const std::map<Operation, std::string> combiner_map = {
             { Operation::Replace, "%source1" },
-            { Operation::Modulate, "(%source1 * %source2) / 255" },
+            { Operation::Modulate, "(%source1 * %source2)" },
             { Operation::Add, "(%source1 + %source2)" },
+            { Operation::AddSigned, "(%source1 + %source2) - 0.5" },
             { Operation::Lerp, "lerp(%source1, %source2, %source3)" },
+            { Operation::Subtract, "(%source1 - %source2)" },
+            { Operation::Dot3_RGB, "dot(%source1, %source2)" },
+            { Operation::MultiplyThenAdd, "((%source1 * %source2) + %source3)" },
+            { Operation::AddThenMultiply, "((%source1 + %source2) * %source3)" },
         };
 
         static auto ReplacePattern =

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -696,115 +696,110 @@ finalise:
 #endif
 }
 
-void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig,6>& stages)
-{
-    using Source = Pica::Regs::TevStageConfig::Source;
-    using ColorModifier = Pica::Regs::TevStageConfig::ColorModifier;
-    using AlphaModifier = Pica::Regs::TevStageConfig::AlphaModifier;
-    using Operation = Pica::Regs::TevStageConfig::Operation;
+static std::string ReplacePattern(const std::string& input, const std::string& pattern, const std::string& replacement) {
+    size_t start = input.find(pattern);
+    if (start == std::string::npos)
+        return input;
 
+    std::string ret = input;
+    ret.replace(start, pattern.length(), replacement);
+    return ret;
+}
+
+static std::string GetTevStageConfigSourceStr(const Pica::Regs::TevStageConfig::Source& source) {
+    using Source = Pica::Regs::TevStageConfig::Source;
+    static const std::map<Source, std::string> source_map = {
+        { Source::PrimaryColor,           "PrimaryColor" },
+        { Source::PrimaryFragmentColor,   "PrimaryFragmentColor" },
+        { Source::SecondaryFragmentColor, "SecondaryFragmentColor" },
+        { Source::Texture0,               "Texture0" },
+        { Source::Texture1,               "Texture1" },
+        { Source::Texture2,               "Texture2" },
+        { Source::Texture3,               "Texture3" },
+        { Source::PreviousBuffer,         "PreviousBuffer" },
+        { Source::Constant,               "Constant" },
+        { Source::Previous,               "Previous" },
+    };
+
+    auto src_it = source_map.find(source);
+    std::string src_str = "Unknown";
+    if (src_it != source_map.end())
+        src_str = src_it->second;
+    return src_str;
+}
+
+static std::string GetTevStageConfigColorSourceStr(const Pica::Regs::TevStageConfig::Source& source, const Pica::Regs::TevStageConfig::ColorModifier modifier) {
+    using ColorModifier = Pica::Regs::TevStageConfig::ColorModifier;
+    static const std::map<ColorModifier, std::string> color_modifier_map = {
+        { ColorModifier::SourceColor, { "%source.rgb" } },
+        { ColorModifier::SourceAlpha, { "%source.aaa" } },
+    };
+
+    auto src_str = GetTevStageConfigSourceStr(source);
+    auto modifier_it = color_modifier_map.find(modifier);
+    std::string modifier_str = "%source.????";
+    if (modifier_it != color_modifier_map.end())
+        modifier_str = modifier_it->second;
+
+    return ReplacePattern(modifier_str, "%source", src_str);
+}
+
+static std::string GetTevStageConfigAlphaSourceStr(const Pica::Regs::TevStageConfig::Source& source, const Pica::Regs::TevStageConfig::AlphaModifier modifier) {
+    using AlphaModifier = Pica::Regs::TevStageConfig::AlphaModifier;
+    static const std::map<AlphaModifier, std::string> alpha_modifier_map = {
+        { AlphaModifier::SourceAlpha, "%source.a" },
+        { AlphaModifier::OneMinusSourceAlpha, "(1.0 - %source.a)" },
+    };
+
+    auto src_str = GetTevStageConfigSourceStr(source);
+    auto modifier_it = alpha_modifier_map.find(modifier);
+    std::string modifier_str = "%source.????";
+    if (modifier_it != alpha_modifier_map.end())
+        modifier_str = modifier_it->second;
+
+    return ReplacePattern(modifier_str, "%source", src_str);
+}
+
+static std::string GetTevStageConfigOperationStr(const Pica::Regs::TevStageConfig::Operation& operation) {
+    using Operation = Pica::Regs::TevStageConfig::Operation;
+    static const std::map<Operation, std::string> combiner_map = {
+        { Operation::Replace, "%source1" },
+        { Operation::Modulate, "(%source1 * %source2)" },
+        { Operation::Add, "(%source1 + %source2)" },
+        { Operation::AddSigned, "(%source1 + %source2) - 0.5" },
+        { Operation::Lerp, "lerp(%source1, %source2, %source3)" },
+        { Operation::Subtract, "(%source1 - %source2)" },
+        { Operation::Dot3_RGB, "dot(%source1, %source2)" },
+        { Operation::MultiplyThenAdd, "((%source1 * %source2) + %source3)" },
+        { Operation::AddThenMultiply, "((%source1 + %source2) * %source3)" },
+    };
+    auto op_it = combiner_map.find(operation);
+    std::string op_str = "Unknown op (%source1, %source2, %source3)";
+    if (op_it != combiner_map.end())
+        op_str = op_it->second;
+    return op_str;
+}
+
+std::string GetTevStageConfigColorCombinerStr(const Pica::Regs::TevStageConfig& tev_stage) {
+    auto op_str = GetTevStageConfigOperationStr(tev_stage.color_op);
+    op_str = ReplacePattern(op_str, "%source1", GetTevStageConfigColorSourceStr(tev_stage.color_source1, tev_stage.color_modifier1));
+    op_str = ReplacePattern(op_str, "%source2", GetTevStageConfigColorSourceStr(tev_stage.color_source2, tev_stage.color_modifier2));
+    return   ReplacePattern(op_str, "%source3", GetTevStageConfigColorSourceStr(tev_stage.color_source3, tev_stage.color_modifier3));
+}
+
+std::string GetTevStageConfigAlphaCombinerStr(const Pica::Regs::TevStageConfig& tev_stage) {
+    auto op_str = GetTevStageConfigOperationStr(tev_stage.alpha_op);
+    op_str = ReplacePattern(op_str, "%source1", GetTevStageConfigAlphaSourceStr(tev_stage.alpha_source1, tev_stage.alpha_modifier1));
+    op_str = ReplacePattern(op_str, "%source2", GetTevStageConfigAlphaSourceStr(tev_stage.alpha_source2, tev_stage.alpha_modifier2));
+    return   ReplacePattern(op_str, "%source3", GetTevStageConfigAlphaSourceStr(tev_stage.alpha_source3, tev_stage.alpha_modifier3));
+}
+
+void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig,6>& stages) {
     std::string stage_info = "Tev setup:\n";
     for (size_t index = 0; index < stages.size(); ++index) {
         const auto& tev_stage = stages[index];
-
-        static const std::map<Source, std::string> source_map = {
-            { Source::PrimaryColor,           "PrimaryColor" },
-            { Source::PrimaryFragmentColor,   "PrimaryFragmentColor" },
-            { Source::SecondaryFragmentColor, "SecondaryFragmentColor" },
-            { Source::Texture0,               "Texture0" },
-            { Source::Texture1,               "Texture1" },
-            { Source::Texture2,               "Texture2" },
-            { Source::Texture3,               "Texture3" },
-            { Source::PreviousBuffer,         "PreviousBuffer" },
-            { Source::Constant,               "Constant" },
-            { Source::Previous,               "Previous" },
-        };
-
-        static const std::map<ColorModifier, std::string> color_modifier_map = {
-            { ColorModifier::SourceColor, { "%source.rgb" } },
-            { ColorModifier::SourceAlpha, { "%source.aaa" } },
-        };
-        static const std::map<AlphaModifier, std::string> alpha_modifier_map = {
-            { AlphaModifier::SourceAlpha, "%source.a" },
-            { AlphaModifier::OneMinusSourceAlpha, "(1.0 - %source.a)" },
-        };
-
-        static const std::map<Operation, std::string> combiner_map = {
-            { Operation::Replace, "%source1" },
-            { Operation::Modulate, "(%source1 * %source2)" },
-            { Operation::Add, "(%source1 + %source2)" },
-            { Operation::AddSigned, "(%source1 + %source2) - 0.5" },
-            { Operation::Lerp, "lerp(%source1, %source2, %source3)" },
-            { Operation::Subtract, "(%source1 - %source2)" },
-            { Operation::Dot3_RGB, "dot(%source1, %source2)" },
-            { Operation::MultiplyThenAdd, "((%source1 * %source2) + %source3)" },
-            { Operation::AddThenMultiply, "((%source1 + %source2) * %source3)" },
-        };
-
-        static auto ReplacePattern =
-                [](const std::string& input, const std::string& pattern, const std::string& replacement) -> std::string {
-                    size_t start = input.find(pattern);
-                    if (start == std::string::npos)
-                        return input;
-
-                    std::string ret = input;
-                    ret.replace(start, pattern.length(), replacement);
-                    return ret;
-                };
-        static auto GetColorSourceStr =
-                [](const Source& src, const ColorModifier& modifier) {
-                    auto src_it = source_map.find(src);
-                    std::string src_str = "Unknown";
-                    if (src_it != source_map.end())
-                        src_str = src_it->second;
-
-                    auto modifier_it = color_modifier_map.find(modifier);
-                    std::string modifier_str = "%source.????";
-                    if (modifier_it != color_modifier_map.end())
-                        modifier_str = modifier_it->second;
-
-                    return ReplacePattern(modifier_str, "%source", src_str);
-                };
-        static auto GetColorCombinerStr =
-                [](const Regs::TevStageConfig& tev_stage) {
-                    auto op_it = combiner_map.find(tev_stage.color_op);
-                    std::string op_str = "Unknown op (%source1, %source2, %source3)";
-                    if (op_it != combiner_map.end())
-                        op_str = op_it->second;
-
-                    op_str = ReplacePattern(op_str, "%source1", GetColorSourceStr(tev_stage.color_source1, tev_stage.color_modifier1));
-                    op_str = ReplacePattern(op_str, "%source2", GetColorSourceStr(tev_stage.color_source2, tev_stage.color_modifier2));
-                    return   ReplacePattern(op_str, "%source3", GetColorSourceStr(tev_stage.color_source3, tev_stage.color_modifier3));
-                };
-        static auto GetAlphaSourceStr =
-                [](const Source& src, const AlphaModifier& modifier) {
-                    auto src_it = source_map.find(src);
-                    std::string src_str = "Unknown";
-                    if (src_it != source_map.end())
-                        src_str = src_it->second;
-
-                    auto modifier_it = alpha_modifier_map.find(modifier);
-                    std::string modifier_str = "%source.????";
-                    if (modifier_it != alpha_modifier_map.end())
-                        modifier_str = modifier_it->second;
-
-                    return ReplacePattern(modifier_str, "%source", src_str);
-                };
-        static auto GetAlphaCombinerStr =
-                [](const Regs::TevStageConfig& tev_stage) {
-                    auto op_it = combiner_map.find(tev_stage.alpha_op);
-                    std::string op_str = "Unknown op (%source1, %source2, %source3)";
-                    if (op_it != combiner_map.end())
-                        op_str = op_it->second;
-
-                    op_str = ReplacePattern(op_str, "%source1", GetAlphaSourceStr(tev_stage.alpha_source1, tev_stage.alpha_modifier1));
-                    op_str = ReplacePattern(op_str, "%source2", GetAlphaSourceStr(tev_stage.alpha_source2, tev_stage.alpha_modifier2));
-                    return   ReplacePattern(op_str, "%source3", GetAlphaSourceStr(tev_stage.alpha_source3, tev_stage.alpha_modifier3));
-                };
-
-        stage_info += "Stage " + std::to_string(index) + ": " + GetColorCombinerStr(tev_stage) + "   " + GetAlphaCombinerStr(tev_stage) + "\n";
+        stage_info += "Stage " + std::to_string(index) + ": " + GetTevStageConfigColorCombinerStr(tev_stage) + "   " + GetTevStageConfigAlphaCombinerStr(tev_stage) + "\n";
     }
-
     LOG_TRACE(HW_GPU, "%s", stage_info.c_str());
 }
 

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -224,6 +224,10 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const Texture
 
 void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
 
+std::string GetTevStageConfigColorCombinerStr(const Pica::Regs::TevStageConfig& tev_stage);
+std::string GetTevStageConfigAlphaCombinerStr(const Pica::Regs::TevStageConfig& tev_stage);
+
+/// Dumps the Tev stage config to log at trace level
 void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig,6>& stages);
 
 /**


### PR DESCRIPTION
This will make it easier to have a GUI combiner / Tev debugger later.
It also extends the Tev dumper by new source types and operations.

I've decided to only prototype the 3 most important functions in the header. One to get a string for a stage alpha channel, one for the color channel and the function to dump all stages at once (which existed before).

This also changes display of the functions from byte style to float style (which is more common in the graphics world). If we end up wanting to show actual GPU register values we'll have to replace said code anyway + I don't think it will happen anytime soon.

It should be noted that the current `DumpTevStageConfig` function is pretty useless because the `Pica::g_state.regs.GetTevStages()` call is usually inlined = we can't do it live in a debugging session with optimizations.
I didn't want to get rid of the parameter option though and didn't want to overload it either.
- I'll probably work on a GUI later anyway.
