### PR TITLE
Make shader code less VS-specific

### DIFF
--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -522,8 +522,7 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     info.labels.insert({entry_point, "main"});
 
     // Generate debug information
-    debug_data = Pica::g_state.vs.ProduceDebugInfo(input_vertex, num_attributes, shader_config,
-                                                   shader_setup);
+    debug_data = shader_setup.ProduceDebugInfo(input_vertex, num_attributes, shader_config);
 
     // Reload widget state
     for (int attr = 0; attr < num_attributes; ++attr) {

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -145,7 +145,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     if (g_debug_context)
                         g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                                  static_cast<void*>(&immediate_input));
-                    g_state.vs.Run(shader_unit, immediate_input, regs.vs.num_input_attributes + 1);
+                    g_state.vs.Run(shader_unit, immediate_input, regs.vs.num_input_attributes + 1,
+                                   regs.vs);
                     Shader::OutputVertex output_vertex =
                         shader_unit.output_registers.ToVertex(regs.vs);
 
@@ -278,7 +279,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (g_debug_context)
                     g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                              (void*)&input);
-                g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes());
+                g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes(), regs.vs);
                 output_registers = shader_unit.output_registers;
 
                 // Retrieve vertex from register data

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -101,6 +101,8 @@ void ShaderSetup::Setup() {
             jit_shader = shader;
             shader_map[cache_key] = std::move(shader);
         }
+    } else {
+        jit_shader.reset();
     }
 #endif // ARCHITECTURE_x86_64
 }
@@ -125,8 +127,8 @@ void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num
     state.conditional_code[1] = false;
 
 #ifdef ARCHITECTURE_x86_64
-    if (VideoCore::g_shader_jit_enabled)
-        jit_shader.lock().get()->Run(*this, state, config.main_offset);
+    if (auto shader = jit_shader.lock())
+        shader.get()->Run(*this, state, config.main_offset);
     else
         RunInterpreter(*this, state, config.main_offset);
 #else

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -77,8 +77,7 @@ OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) {
 }
 
 #ifdef ARCHITECTURE_x86_64
-static std::unordered_map<u64, std::unique_ptr<JitShader>> shader_map;
-static const JitShader* jit_shader;
+static std::unordered_map<u64, std::shared_ptr<JitShader>> shader_map;
 #endif // ARCHITECTURE_x86_64
 
 void ClearCache() {
@@ -90,17 +89,16 @@ void ClearCache() {
 void ShaderSetup::Setup() {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
-        u64 cache_key =
-            Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
-            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data));
+        u64 cache_key = (Common::ComputeHash64(&program_code, sizeof(program_code)) ^
+                         Common::ComputeHash64(&swizzle_data, sizeof(swizzle_data)));
 
         auto iter = shader_map.find(cache_key);
         if (iter != shader_map.end()) {
-            jit_shader = iter->second.get();
+            jit_shader = iter->second;
         } else {
-            auto shader = std::make_unique<JitShader>();
-            shader->Compile();
-            jit_shader = shader.get();
+            auto shader = std::make_shared<JitShader>();
+            shader->Compile(*this);
+            jit_shader = shader;
             shader_map[cache_key] = std::move(shader);
         }
     }
@@ -109,9 +107,8 @@ void ShaderSetup::Setup() {
 
 MICROPROFILE_DEFINE(GPU_Shader, "GPU", "Shader", MP_RGB(50, 50, 240));
 
-void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num_attributes) {
-    auto& config = g_state.regs.vs;
-    auto& setup = g_state.vs;
+void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num_attributes,
+                      const Regs::ShaderConfig& config) {
 
     MICROPROFILE_SCOPE(GPU_Shader);
 
@@ -129,17 +126,16 @@ void ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num
 
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled)
-        jit_shader->Run(setup, state, config.main_offset);
+        jit_shader.lock().get()->Run(*this, state, config.main_offset);
     else
-        RunInterpreter(setup, state, config.main_offset);
+        RunInterpreter(*this, state, config.main_offset);
 #else
-    RunInterpreter(setup, state, config.main_offset);
+    RunInterpreter(*this, state, config.main_offset);
 #endif // ARCHITECTURE_x86_64
 }
 
 DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_attributes,
-                                              const Regs::ShaderConfig& config,
-                                              const ShaderSetup& setup) {
+                                              const Regs::ShaderConfig& config) {
     UnitState<true> state;
 
     state.debug.max_offset = 0;
@@ -154,7 +150,7 @@ DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_
     state.conditional_code[0] = false;
     state.conditional_code[1] = false;
 
-    RunInterpreter(setup, state, config.main_offset);
+    RunInterpreter(*this, state, config.main_offset);
     return state.debug;
 }
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -26,6 +26,12 @@ namespace Pica {
 
 namespace Shader {
 
+#ifdef ARCHITECTURE_x86_64
+// Forward declare JitShader because shader_jit_x64.h requires ShaderSetup
+// (which uses JitShader) from this file
+class JitShader;
+#endif // ARCHITECTURE_x86_64
+
 struct InputVertex {
     alignas(16) Math::Vec4<float24> attr[16];
 };
@@ -352,6 +358,10 @@ struct ShaderSetup {
     std::array<u32, 1024> program_code;
     std::array<u32, 1024> swizzle_data;
 
+#ifdef ARCHITECTURE_x86_64
+    std::weak_ptr<const JitShader> jit_shader;
+#endif
+
     /**
      * Performs any shader unit setup that only needs to happen once per shader (as opposed to once
      * per vertex, which would happen within the `Run` function).
@@ -363,19 +373,20 @@ struct ShaderSetup {
      * @param state Shader unit state, must be setup per shader and per shader unit
      * @param input Input vertex into the shader
      * @param num_attributes The number of vertex shader attributes
+     * @param config Configuration object for the shader pipeline
      */
-    void Run(UnitState<false>& state, const InputVertex& input, int num_attributes);
+    void Run(UnitState<false>& state, const InputVertex& input, int num_attributes,
+             const Regs::ShaderConfig& config);
 
     /**
      * Produce debug information based on the given shader and input vertex
      * @param input Input vertex into the shader
      * @param num_attributes The number of vertex shader attributes
      * @param config Configuration object for the shader pipeline
-     * @param setup Setup object for the shader pipeline
      * @return Debug information for this shader with regards to the given vertex
      */
     DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes,
-                                     const Regs::ShaderConfig& config, const ShaderSetup& setup);
+                                     const Regs::ShaderConfig& config);
 };
 
 } // namespace Shader

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -44,9 +44,9 @@ void RunInterpreter(const ShaderSetup& setup, UnitState<Debug>& state, unsigned 
 
     u32 program_counter = offset;
 
-    const auto& uniforms = g_state.vs.uniforms;
-    const auto& swizzle_data = g_state.vs.swizzle_data;
-    const auto& program_code = g_state.vs.program_code;
+    const auto& uniforms = setup.uniforms;
+    const auto& swizzle_data = setup.swizzle_data;
+    const auto& program_code = setup.program_code;
 
     // Placeholder for invalid inputs
     static float24 dummy_vec4_float24[4];

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -37,7 +37,7 @@ public:
         program(&setup, &state, code_ptr[offset]);
     }
 
-    void Compile();
+    void Compile(const ShaderSetup& setup);
 
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
@@ -97,6 +97,17 @@ private:
     void Compile_Assert(bool condition, const char* msg);
 
     /**
+     * Get the shader instruction for a given offset in the current shader program
+     * @param offset Offset in the current shader program of the instruction
+     * @return Instruction at the specified offset
+     */
+    Instruction GetShaderInstruction(size_t offset) {
+        Instruction instruction;
+        std::memcpy(&instruction, &setup->program_code[offset], sizeof(Instruction));
+        return instruction;
+    }
+
+    /**
      * Analyzes the entire shader program for `CALL` instructions before emitting any code,
      * identifying the locations where a return needs to be inserted.
      */
@@ -116,6 +127,8 @@ private:
 
     using CompiledShader = void(const void* setup, void* state, const u8* start_addr);
     CompiledShader* program = nullptr;
+
+    const ShaderSetup* setup = nullptr;
 };
 
 } // Shader


### PR DESCRIPTION
# Make shader code less VS-specific

The current implementation of `ShaderSetup` was left half-complete in #1780. Some member functions still require a `ShaderSetup*` as argument. This commit finally fixes that. Said functions operate on member variables now.

The current implementation in master also has most shader related functions hardcoded to use the vertex shader state (represented by `ShaderConfig` and `ShaderSetup` structs).
This commit changes that by adding `ShaderConfig` (which is the shader state in the Pica regs) parameters  to all calls dealing with shaders. This way we can use the same shader functions to use the current Pica VS / GS configuration and operate on the VS / GS setup (= state).


The `JitShader` needs a forward declaration due to `jit_shader` being part of shader.h (`ShaderSetup` now) and shader_jit_x64.h depending on `ShaderSetup` (shader.h).

This also introduces a hacky pointer variable called setup in the JIT struct as the JIT compilation process requires access to `ShaderSetup` but I found no way to add it otherwise.
The pointer is only valid during compilation and will be `nullptr` otherwise. It's sole purpose is to retrieve the shader code / instructions for the shader type (either VS or GS later).
Alternative design suggestions for this are welcome! I'd like to avoid the pointer myself.

# Only check for JIT in Setup

This should fix #1051. The check wether JIT is enabled has been moved to `::Setup`.
A `weak_ptr` is used so a cache clear really destroys all shaders.

Note: This introduces a tiny issue if jit cache is cleared betwen `::Setup` and `::Run`. As no shader_jit will exist (due to cache clear), it will run the interpreter, even if shader-jit is enabled in the config. The issue is obviously fixed on the next call to `::Setup`, so unless a cache clear is hammered this should rarely happen. I think this is totally fine but others might think it's against the users wish - however, that'd be a seperate issue in my opinion.

---
(This PR is part of my GS branch)


---

TODO:

- [ ] PR Desc
- [ ] Cleanup