### PR TITLE
Warn about x64 specific features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,8 +254,10 @@ set(INI_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/externals/inih")
 include_directories(${INI_PREFIX})
 add_subdirectory(${INI_PREFIX})
 
-option(DYNARMIC_TESTS OFF)
-add_subdirectory(externals/dynarmic)
+if(ARCHITECTURE_x86_64)
+    option(DYNARMIC_TESTS OFF)
+    add_subdirectory(externals/dynarmic)
+endif()
 
 add_subdirectory(externals/glad)
 include_directories(externals/microprofile)

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -15,6 +15,11 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->toggle_cpu_jit->setEnabled(!System::IsPoweredOn());
+#ifndef ARCHITECTURE_x86_64
+    ui->toggle_cpu_jit->hide();
+    // As the CPU JIT option is the only Performance option, we can hide the entire box
+    ui->performance_box->hide();
+#endif // ARCHITECTURE_x86_64
 }
 
 ConfigureGeneral::~ConfigureGeneral() {}

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -44,7 +44,7 @@
       </widget>
      </item>
       <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="performance_box">
           <property name="title">
             <string>Performance</string>
           </property>

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -14,6 +14,9 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     this->setConfiguration();
 
     ui->toggle_vsync->setEnabled(!System::IsPoweredOn());
+#ifndef ARCHITECTURE_x86_64
+    ui->toggle_shader_jit->hide();
+#endif // ARCHITECTURE_x86_64
 }
 
 ConfigureGraphics::~ConfigureGraphics() {}

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -215,6 +215,14 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
         Common::StringFromFormat("Citra | %s-%s", Common::g_scm_branch, Common::g_scm_desc);
     setWindowTitle(window_title.c_str());
 
+#ifndef ARCHITECTURE_x86_64
+    // Non-x64 does not have any form of JIT yet.
+    QMessageBox::warning(this, tr("Unsupported platform!"),
+                         tr("Citra does not support the platform you are running on.\n\n"
+                            "Some optimizations will not be available and won't appear in the Configuration.\n"
+                            "Expect poor performance. Do not ask for support!"));
+#endif
+
     show();
 
     game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(SRCS
             arm/disassembler/arm_disasm.cpp
             arm/disassembler/load_symbol_map.cpp
-            arm/dynarmic/arm_dynarmic.cpp
             arm/dyncom/arm_dyncom.cpp
             arm/dyncom/arm_dyncom_dec.cpp
             arm/dyncom/arm_dyncom_interpreter.cpp
@@ -159,7 +158,6 @@ set(HEADERS
             arm/arm_interface.h
             arm/disassembler/arm_disasm.h
             arm/disassembler/load_symbol_map.h
-            arm/dynarmic/arm_dynarmic.h
             arm/dyncom/arm_dyncom.h
             arm/dyncom/arm_dyncom_dec.h
             arm/dyncom/arm_dyncom_interpreter.h
@@ -321,10 +319,20 @@ set(HEADERS
             system.h
             )
 
-include_directories(../../externals/dynarmic/include)
+if(ARCHITECTURE_x86_64)
+    set(SRCS ${SRCS}
+            arm/dynarmic/arm_dynarmic.cpp)
+
+    set(HEADERS ${HEADERS}
+            arm/dynarmic/arm_dynarmic.h)
+
+    include_directories(../../externals/dynarmic/include)
+endif()
 
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_library(core STATIC ${SRCS} ${HEADERS})
 
-target_link_libraries(core dynarmic)
+if(ARCHITECTURE_x86_64)
+    target_link_libraries(core dynarmic)
+endif()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -5,7 +5,9 @@
 #include <memory>
 #include "common/logging/log.h"
 #include "core/arm/arm_interface.h"
+#ifdef ARCHITECTURE_x86_64
 #include "core/arm/dynarmic/arm_dynarmic.h"
+#endif // ARCHITECTURE_x86_64
 #include "core/arm/dyncom/arm_dyncom.h"
 #include "core/core.h"
 #include "core/core_timing.h"
@@ -71,6 +73,7 @@ void Stop() {
 
 /// Initialize the core
 void Init() {
+#ifdef ARCHITECTURE_x86_64
     if (Settings::values.use_cpu_jit) {
         g_sys_core = std::make_unique<ARM_Dynarmic>(USER32MODE);
         g_app_core = std::make_unique<ARM_Dynarmic>(USER32MODE);
@@ -78,6 +81,13 @@ void Init() {
         g_sys_core = std::make_unique<ARM_DynCom>(USER32MODE);
         g_app_core = std::make_unique<ARM_DynCom>(USER32MODE);
     }
+#else
+    if (Settings::values.use_cpu_jit) {
+        LOG_WARNING(Core, "Using CPU Interpreter. CPU JIT is activated in config but not available on current platform!");
+    }
+    g_sys_core = std::make_unique<ARM_DynCom>(USER32MODE);
+    g_app_core = std::make_unique<ARM_DynCom>(USER32MODE);
+#endif // ARCHITECTURE_x86_64
 
     LOG_DEBUG(Core, "Initialized OK");
 }


### PR DESCRIPTION
# Warn about x64 features

Ever since dynarmic was added, it was impossible to compile for non x64 platforms apparently.
This PR addresses this by warning users that dynarmic is not available in non-x64:
- SDL: LOG_WARN about poor performance on non-x64 builds
- Qt: Message box about poor performance on non-x64 builds and that some options won't be available. The respective menu options are also hidden in the Qt GUI.

Settings::Apply will also generate a LOG_WARN if JIT (either CPU or Shader JIT) is actived in settings.

---

TODO:

- [x] Rebase onto mingw fix on merge
- [ ] Move GL 3.3 warning to startup
- [x] Split PRs
  - [x] Remove check for Qt5
  - [ ] Correct comment on ENABLE_SDL2 option
    - [ ] Support older GL versions as fallback
- [ ] Plenty
- [ ] Warnings
- [ ] Hiding menu options