### PR TITLE
citra-qt: Add translation support

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -83,7 +83,24 @@ set(UIS
             main.ui
             )
 
-create_directory_groups(${SRCS} ${HEADERS} ${UIS})
+set(LANGS
+            translation/language_de.ts
+            translation/language_en.ts
+)
+
+find_package(Qt5LinguistTools REQUIRED)
+
+# Some packages might be in the system include path, qt5_create_translation is poorly written
+# and will explicitly list all INCLUDE_DIRECTORIES for translation search which would take hours.
+# To avoid this we first clear the list, and then restore it afterwards..
+get_directory_property(_inc_DIRS INCLUDE_DIRECTORIES)
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "")
+qt5_create_translation(TRANSLATIONS ${SRCS} ${HEADERS} ${UIS} ${LANGS})
+set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${_inc_DIRS}")
+
+#qt5_add_translation(TRANSLATIONS ${LANGS})
+
+create_directory_groups(${SRCS} ${HEADERS} ${UIS} ${LANGS})
 
 if (Qt5_FOUND)
     qt5_wrap_ui(UI_HDRS ${UIS})
@@ -94,10 +111,10 @@ endif()
 if (APPLE)
     set(MACOSX_ICON "../../dist/citra.icns")
     set_source_files_properties(${MACOSX_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-    add_executable(citra-qt MACOSX_BUNDLE ${SRCS} ${HEADERS} ${UI_HDRS} ${MACOSX_ICON})
+    add_executable(citra-qt MACOSX_BUNDLE ${SRCS} ${HEADERS} ${UI_HDRS} ${TRANSLATIONS} ${MACOSX_ICON})
     set_target_properties(citra-qt PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 else()
-    add_executable(citra-qt ${SRCS} ${HEADERS} ${UI_HDRS})
+    add_executable(citra-qt ${SRCS} ${HEADERS} ${UI_HDRS} ${TRANSLATIONS})
 endif()
 target_link_libraries(citra-qt core video_core audio_core common qhexedit)
 target_link_libraries(citra-qt ${OPENGL_gl_LIBRARY} ${CITRA_QT_LIBS})

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -8,6 +8,8 @@
 #include "core/system.h"
 #include "ui_configure_general.h"
 
+#include <QDir>
+
 ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGeneral) {
 
@@ -15,6 +17,39 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->toggle_cpu_jit->setEnabled(!System::IsPoweredOn());
+
+    // format systems language
+    QString defaultLocale = QLocale::system().name(); // e.g. "de_DE"
+    defaultLocale.truncate(defaultLocale.lastIndexOf('_')); // e.g. "de"
+
+    QString m_langPath = QApplication::applicationDirPath();
+    m_langPath.append("/languages");
+    QDir dir(m_langPath);
+    QStringList fileNames = dir.entryList(QStringList("*.qm"));
+
+    for (int i = 0; i < fileNames.size(); ++i) {
+        // get locale extracted by filename
+        QString locale;
+        locale = fileNames[i]; // "de.qm"
+        locale.truncate(locale.lastIndexOf('.')); // "de"
+
+        QString lang = QLocale::languageToString(QLocale(locale).language());
+
+        ui->language_combobox->addItem(lang);
+/*
+        QAction *action = new QAction(ico, lang, this);
+        action->setCheckable(true);
+        action->setData(locale);
+
+        ui.menuLanguage->addAction(action);
+        langGroup->addAction(action);
+
+        // set default translators and language checked
+        if (defaultLocale == locale) {
+            action->setChecked(true);
+        }
+*/
+    }
 }
 
 ConfigureGeneral::~ConfigureGeneral() {}

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -25,6 +25,26 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="label2">
+              <property name="text">
+               <string>Language:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="language_combobox">
+              <item>
+               <property name="text">
+                <string notr="true">dummy</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QCheckBox" name="toggle_deepscan">
             <property name="text">
              <string>Recursive scan for game folder</string>


### PR DESCRIPTION
After lots of wrestling with `lupdate` (Qt5 Linguist Tools) I've actually made this partially work.
It adds a translation selector in the citra-qt configuration.

This includes german and english as example languages

---

TODO:
- [ ] Search in another folder?!
- [ ] Include precompiled translations or decide good deployment strategy
- [ ] Fix german translation
- [ ] Add translation to gitignore?!
- [ ] Activate translations