### PR TITLE
Lighting LUT Quickfix

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -110,6 +110,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
         glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, 256, 0, GL_RGBA, GL_FLOAT, nullptr);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     }
 
     // Setup the LUT for the fog

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -293,7 +293,7 @@ static void AppendAlphaTestCondition(std::string& out, Regs::CompareFunc func) {
     case CompareFunc::GreaterThanOrEqual: {
         static const char* op[] = {"!=", "==", ">=", ">", "<=", "<"};
         unsigned index = (unsigned)func - (unsigned)CompareFunc::Equal;
-        out += "int(last_tex_env_out.a * 255.0f) " + std::string(op[index]) + " alphatest_ref";
+        out += "int(last_tex_env_out.a * 255.0) " + std::string(op[index]) + " alphatest_ref";
         break;
     }
 
@@ -422,11 +422,11 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         if (abs) {
             // LUT index is in the range of (0.0, 1.0)
             index = lighting.light[light_num].two_sided_diffuse ? "abs(" + index + ")"
-                                                                : "max(" + index + ", 0.f)";
+                                                                : "max(" + index + ", 0.0)";
             return "(" + index + ")";
         } else {
             // LUT index is in the range of (-1.0, 1.0)
-            return "(((" + index + " < 0) ? " + index + " + 2.0 : " + index +
+            return "(((" + index + " < 0.0) ? " + index + " + 2.0 : " + index +
                    ") / 2.0)";
         }
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -423,11 +423,10 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
             // LUT index is in the range of (0.0, 1.0)
             index = lighting.light[light_num].two_sided_diffuse ? "abs(" + index + ")"
                                                                 : "max(" + index + ", 0.f)";
-            return "(FLOAT_255 * clamp(" + index + ", 0.0, 1.0))";
+            return "(" + index + ")";
         } else {
             // LUT index is in the range of (-1.0, 1.0)
-            index = "clamp(" + index + ", -1.0, 1.0)";
-            return "(FLOAT_255 * ((" + index + " < 0) ? " + index + " + 2.0 : " + index +
+            return "(((" + index + " < 0) ? " + index + " + 2.0 : " + index +
                    ") / 2.0)";
         }
 
@@ -462,7 +461,6 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         if (light_config.dist_atten_enable) {
             std::string index = "(" + light_src + ".dist_atten_scale * length(-view - " +
                                 light_src + ".position) + " + light_src + ".dist_atten_bias)";
-            index = "((clamp(" + index + ", 0.0, FLOAT_255)))";
             const unsigned lut_num =
                 ((unsigned)Regs::LightingSampler::DistanceAttenuation + light_config.num);
             dist_atten = GetLutValue((Regs::LightingSampler)lut_num, index);
@@ -581,7 +579,6 @@ std::string GenerateFragmentShader(const PicaShaderConfig& config) {
 #define NUM_TEV_STAGES 6
 #define NUM_LIGHTS 8
 #define LIGHTING_LUT_SIZE 256
-#define FLOAT_255 (255.0 / 256.0)
 
 in vec4 primary_color;
 in vec2 texcoord[3];


### PR DESCRIPTION
This fixes the broken lighting in Zelda: ALBW (As reported by Migue via Discord).

The error is caused by a wrapping of the texture in `LUT[4]` (`GL_TEXTURE_7`) where the red channel (so `texture(LUT[4], index)[0])` will be a ramp from 0.0 to 1.0 accross the width of 256.
Hence turning samples at 0.0 into 0.5 (average of 0.0 and 1.0).

Note that this also removes the scaling with `255.0/256.0` (`FLOAT_255`) because I'm not sure what it was supposed to do (as offsetting from 0.0 wasn't done and scaling would have to be done using: `1.0/256.0 + 254.0/256.0 * index`).

Aside from that, this PR removes some ugly float suffixes and implicit conversions in GLSL.
The whole shader_gen deserves a rewrite, but that is a seperate issue.

---

@degasus pointed out that glTexSubImage1D is probably a lot worse than buffer textures.
So in the future, we should be rewriting the whole LUT (lighting and fog) upload code.
This would also give us the option to adapt a better interpolation like the fog LUT already does (albeit being very slow / stupid in GLSL in the case of the fog LUT).
However, I consider that a seperate issue. So this quickfix will have to do for now.

---

TODO:

- [x] Test with various games
- [x] Cleanup
- [x] Decide wether to PR this or do what degasus suggested in combination with a full refactor
