### PR TITLE
TexCoord map

### DIFF
--- a/src/video_core/regs_texturing.h
+++ b/src/video_core/regs_texturing.h
@@ -122,6 +122,10 @@ struct TexturingRegs {
         BitField<0, 1, u32> texture0_enable;
         BitField<1, 1, u32> texture1_enable;
         BitField<2, 1, u32> texture2_enable;
+
+        BitField<8, 2, u32> texture3_coord;
+
+        BitField<13, 1, u32> texture2_coord;
     };
     TextureConfig texture0;
     INSERT_PADDING_WORDS(0x8);

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -79,6 +79,8 @@ union PicaShaderConfig {
         Pica::FramebufferRegs::CompareFunc alpha_test_func;
         Pica::RasterizerRegs::ScissorMode scissor_test_mode;
         Pica::TexturingRegs::TextureConfig::TextureType texture0_type;
+        unsigned texture2_coord;
+        unsigned texture3_coord;
         std::array<TevStageConfigRaw, 6> tev_stages;
         u8 combiner_buffer_input;
 


### PR DESCRIPTION
According to https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_TEXUNIT_CONFIG texture units 2 and 3 can also use texture coordinates meant for another texture unit.

This PR implements that behaviour.

---

Code wise there are some bad decisions in this one, however, they copy the existing style.
In the future we should decide wether we want PicaShaderConfig to be an almost exact replica / subset of our Pica state or if we want it to interpret / abstract some values.
Keeping a subset moves more Pica logic into each rendering backend, making it harder to maintain those / abstracting data can make it larger (we have an enum to float conversion for example) which is bad for the cache lookup. Adding a set of intermediate / abstract enums etc. creates an arbitrary API which new developers would have to learn (in addition to Pica and the rendering backend).
However, this discussion is far beyond of the scope

---

We need a couple of hardware tests to confirm exact behaviour:

- Do these mappings "stack"? e.g. what happens if TEXTURE2 uses texCoord 1 and TEXTURE3 uses texCoord 2 ? Would TEXTURE3 use the original texCoord 2 coordinates or would it also use texCoord 1?
I'm assuming independent / non-stacking behaviour at this point.
- Do these also affect the bump-selector?
I'm assuming yes as the bump-selector is choosing a texture unit and the texCoord configuration is part of the texture setup (not the combiner setup)
- Does this only map the texture coord or also the wrapping and / or interpolation behaviour?
I'm assuming this only affects input texCoords, so not wrapping or interpolation
However, I consider it beyond the scope of this PR. It's probably not too commonly used anyway.

---

This fixes a bug in Kid Icarus (when merged with mailwl/kid ) where the alpha lookup from TEXTURE2 would use the same texcoord as RGB lookup from TEXTURE1:

**Broken**

![Broken]()

**Working**

![Working]()

---

TODO:

- [x] Rebase to master
- [ ] Move code discussion into a seperate issue
- [ ] Cleanup
- [ ] sw-renderer