### PR TITLE
.

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -32,10 +32,6 @@ namespace Pica {
 
 namespace CommandProcessor {
 
-static int float_regs_counter = 0;
-
-static u32 uniform_write_buffer[4];
-
 static int default_attr_counter = 0;
 
 static u32 default_attr_write_buffer[3];
@@ -331,22 +327,23 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     }
 
     case PICA_REG_INDEX(vs.bool_uniforms):
-        for (unsigned i = 0; i < 16; ++i)
-            g_state.vs.uniforms.b[i] = (regs.vs.bool_uniforms.Value() & (1 << i)) != 0;
-
+        Shader::WriteUniformBoolReg(false, value);
         break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[1], 0x2b2):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[2], 0x2b3):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[3], 0x2b4): {
-        int index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
         auto values = regs.vs.int_uniforms[index];
-        g_state.vs.uniforms.i[index] = Math::Vec4<u8>(values.x, values.y, values.z, values.w);
-        LOG_TRACE(HW_GPU, "Set integer uniform %d to %02x %02x %02x %02x", index, values.x.Value(),
-                  values.y.Value(), values.z.Value(), values.w.Value());
+        Shader::WriteUniformIntReg(false, index,
+                                   Math::Vec4<u8>(values.x, values.y, values.z, values.w));
         break;
     }
+
+    case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.setup, 0x2c0):
+        Shader::WriteUniformFloatSetupReg(false, value);
+        break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[0], 0x2c1):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[1], 0x2c2):
@@ -356,51 +353,15 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[5], 0x2c6):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[6], 0x2c7):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[7], 0x2c8): {
-        auto& uniform_setup = regs.vs.uniform_setup;
-
-        // TODO: Does actual hardware indeed keep an intermediate buffer or does
-        //       it directly write the values?
-        uniform_write_buffer[float_regs_counter++] = value;
-
-        // Uniforms are written in a packed format such that four float24 values are encoded in
-        // three 32-bit numbers. We write to internal memory once a full such vector is
-        // written.
-        if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
-            (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
-            float_regs_counter = 0;
-
-            auto& uniform = g_state.vs.uniforms.f[uniform_setup.index];
-
-            if (uniform_setup.index > 95) {
-                LOG_ERROR(HW_GPU, "Invalid VS uniform index %d", (int)uniform_setup.index);
-                break;
-            }
-
-            // NOTE: The destination component order indeed is "backwards"
-            if (uniform_setup.IsFloat32()) {
-                for (auto i : {0, 1, 2, 3})
-                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
-            } else {
-                // TODO: Untested
-                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
-                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
-                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
-                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
-                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
-                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
-            }
-
-            LOG_TRACE(HW_GPU, "Set uniform %x to (%f %f %f %f)", (int)uniform_setup.index,
-                      uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
-                      uniform.w.ToFloat32());
-
-            // TODO: Verify that this actually modifies the register!
-            uniform_setup.index.Assign(uniform_setup.index + 1);
-        }
+        Shader::WriteUniformFloatReg(false, value);
         break;
     }
 
     // Load shader program code
+    case PICA_REG_INDEX_WORKAROUND(vs.program.offset, 0x2cb):
+        Shader::WriteProgramCodeOffset(false, value);
+        break;
+
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[0], 0x2cc):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[1], 0x2cd):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[2], 0x2ce):
@@ -409,12 +370,15 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[5], 0x2d1):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[6], 0x2d2):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[7], 0x2d3): {
-        g_state.vs.program_code[regs.vs.program.offset] = value;
-        regs.vs.program.offset++;
+        Shader::WriteProgramCode(false, value);
         break;
     }
 
     // Load swizzle pattern data
+    case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.offset, 0x2d5):
+        Shader::WriteSwizzlePatternsOffset(false, value);
+        break;
+
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[0], 0x2d6):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[1], 0x2d7):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[2], 0x2d8):
@@ -423,8 +387,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[5], 0x2db):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[6], 0x2dc):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[7], 0x2dd): {
-        g_state.vs.swizzle_data[regs.vs.swizzle_patterns.offset] = value;
-        regs.vs.swizzle_patterns.offset++;
+        Shader::WriteSwizzlePatterns(false, value);
         break;
     }
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -326,6 +326,71 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         break;
     }
 
+    case PICA_REG_INDEX(gs.bool_uniforms):
+        Shader::WriteUniformBoolReg(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[1], 0x282):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[2], 0x283):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[3], 0x284): {
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281));
+        auto values = regs.gs.int_uniforms[index];
+        Shader::WriteUniformIntReg(true, index,
+                                   Math::Vec4<u8>(values.x, values.y, values.z, values.w));
+        break;
+    }
+
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.setup, 0x290):
+        Shader::WriteUniformFloatSetupReg(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[0], 0x291):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[1], 0x292):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[2], 0x293):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[3], 0x294):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[4], 0x295):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[5], 0x296):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[6], 0x297):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[7], 0x298): {
+        Shader::WriteUniformFloatReg(true, value);
+        break;
+    }
+
+    // Load shader program code
+    case PICA_REG_INDEX_WORKAROUND(gs.program.offset, 0x29b):
+        Shader::WriteProgramCodeOffset(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[0], 0x29c):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[1], 0x29d):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[2], 0x29e):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[3], 0x29f):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[4], 0x2a0):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[5], 0x2a1):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[6], 0x2a2):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[7], 0x2a3): {
+        Shader::WriteProgramCode(true, value);
+        break;
+    }
+
+    // Load swizzle pattern data
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.offset, 0x2a5):
+        Shader::WriteSwizzlePatternsOffset(true, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[0], 0x2a6):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[1], 0x2a7):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[2], 0x2a8):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[3], 0x2a9):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[4], 0x2aa):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[5], 0x2ab):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[6], 0x2ac):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[7], 0x2ad): {
+        Shader::WriteSwizzlePatterns(true, value);
+        break;
+    }
+
     case PICA_REG_INDEX(vs.bool_uniforms):
         Shader::WriteUniformBoolReg(false, value);
         break;

--- a/src/video_core/regs.h
+++ b/src/video_core/regs.h
@@ -129,7 +129,10 @@ ASSERT_REG_POSITION(pipeline.trigger_draw, 0x22e);
 ASSERT_REG_POSITION(pipeline.trigger_draw_indexed, 0x22f);
 ASSERT_REG_POSITION(pipeline.vs_default_attributes_setup, 0x232);
 ASSERT_REG_POSITION(pipeline.command_buffer, 0x238);
+ASSERT_REG_POSITION(pipeline.vs_com_mode, 0x244);
 ASSERT_REG_POSITION(pipeline.gpu_mode, 0x245);
+ASSERT_REG_POSITION(pipeline.vs_outmap_total1, 0x24A);
+ASSERT_REG_POSITION(pipeline.vs_outmap_total2, 0x251);
 ASSERT_REG_POSITION(pipeline.triangle_topology, 0x25e);
 ASSERT_REG_POSITION(pipeline.restart_primitive, 0x25f);
 

--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -147,7 +147,7 @@ struct PipelineRegs {
     // Number of vertices to render
     u32 num_vertices;
 
-    INSERT_PADDING_WORDS(0x1);
+    BitField<0, 2, u32> use_geometry_shader;
 
     // The index of the first vertex to render
     u32 vertex_offset;
@@ -200,7 +200,14 @@ struct PipelineRegs {
     /// Number of input attributes to the vertex shader minus 1
     BitField<0, 4, u32> max_input_attrib_index;
 
-    INSERT_PADDING_WORDS(2);
+    INSERT_PADDING_WORDS(1);
+
+    enum class VSComMode : u32 {
+        Shared = 0,
+        Exclusive = 1
+    };
+
+    VSComMode vs_com_mode;
 
     enum class GPUMode : u32 {
         Drawing = 0,
@@ -209,7 +216,15 @@ struct PipelineRegs {
 
     GPUMode gpu_mode;
 
-    INSERT_PADDING_WORDS(0x18);
+    INSERT_PADDING_WORDS(0x4);
+
+    BitField<0, 4, u32> vs_outmap_total1;
+
+    INSERT_PADDING_WORDS(0x6);
+
+    BitField<0, 4, u32> vs_outmap_total2;
+
+    INSERT_PADDING_WORDS(0xC);
 
     enum class TriangleTopology : u32 {
         List = 0,
@@ -218,7 +233,10 @@ struct PipelineRegs {
         Shader = 3, // Programmable setup unit implemented in a geometry shader
     };
 
-    BitField<8, 2, TriangleTopology> triangle_topology;
+    union {
+        BitField<0, 4, u32> vs_outmap_count;
+        BitField<8, 2, TriangleTopology> triangle_topology;
+    };
 
     u32 restart_primitive;
 

--- a/src/video_core/regs_shader.h
+++ b/src/video_core/regs_shader.h
@@ -27,6 +27,8 @@ struct ShaderRegs {
     union {
         // Number of input attributes to shader unit - 1
         BitField<0, 4, u32> max_input_attribute_index;
+
+        BitField<24, 8, u32> use_geometry_shader;
     };
 
     // Offset to shader program entry point (in words)

--- a/src/video_core/regs_shader.h
+++ b/src/video_core/regs_shader.h
@@ -60,6 +60,8 @@ struct ShaderRegs {
         }
 
         union {
+            u32 setup;
+
             // Index of the next uniform to write to
             // TODO: ctrulib uses 8 bits for this, however that seems to yield lots of invalid
             // indices

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -109,6 +109,124 @@ void Shutdown() {
 #endif // ARCHITECTURE_x86_64
 }
 
+bool SharedGS() {
+    return g_state.regs.pipeline.vs_com_mode == Pica::PipelineRegs::VSComMode::Shared;
+}
+
+void WriteUniformBoolReg(bool gs, u32 value) {
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    ASSERT(setup.uniforms.b.size() == 16);
+    for (unsigned i = 0; i < 16; ++i)
+        setup.uniforms.b[i] = (value & (1 << i)) != 0;
+}
+
+void WriteUniformIntReg(bool gs, unsigned index, const Math::Vec4<u8>& values) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    ASSERT(index < setup.uniforms.i.size());
+    setup.uniforms.i[index] = values;
+    LOG_TRACE(HW_GPU, "Set %s integer uniform %d to %02x %02x %02x %02x", shader_type, index,
+              values.x.Value(), values.y.Value(), values.z.Value(), values.w.Value());
+}
+
+void WriteUniformFloatSetupReg(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+
+    config.uniform_setup.setup = value;
+}
+
+void WriteUniformFloatReg(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    auto& uniform_setup = config.uniform_setup;
+    auto& uniform_write_buffer = setup.uniform_write_buffer;
+    auto& float_regs_counter = setup.float_regs_counter;
+
+    // TODO: Does actual hardware indeed keep an intermediate buffer or does
+    //       it directly write the values?
+    uniform_write_buffer[float_regs_counter++] = value;
+
+    // Uniforms are written in a packed format such that four float24 values are
+    // encoded in
+    // three 32-bit numbers. We write to internal memory once a full such vector
+    // is
+    // written.
+    if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
+        (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
+        float_regs_counter = 0;
+
+        auto& uniform = setup.uniforms.f[uniform_setup.index];
+
+        if (uniform_setup.index >= 96) {
+            LOG_ERROR(HW_GPU, "Invalid %s float uniform index %d", shader_type,
+                      (int)uniform_setup.index);
+        } else {
+
+            // NOTE: The destination component order indeed is "backwards"
+            if (uniform_setup.IsFloat32()) {
+                for (auto i : {0, 1, 2, 3})
+                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
+            } else {
+                // TODO: Untested
+                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
+                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
+                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
+                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
+                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
+                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
+            }
+
+            LOG_TRACE(HW_GPU, "Set %s float uniform %x to (%f %f %f %f)", shader_type,
+                      (int)uniform_setup.index, uniform.x.ToFloat32(), uniform.y.ToFloat32(),
+                      uniform.z.ToFloat32(), uniform.w.ToFloat32());
+
+            // TODO: Verify that this actually modifies the register!
+            uniform_setup.index.Assign(uniform_setup.index + 1);
+        }
+    }
+}
+
+void WriteProgramCodeOffset(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    config.program.offset = value;
+}
+
+void WriteProgramCode(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    if (config.program.offset >= setup.program_code.size()) {
+        LOG_ERROR(HW_GPU, "Invalid %s program offset %d", shader_type, (int)config.program.offset);
+    } else {
+        setup.program_code[config.program.offset] = value;
+        config.program.offset++;
+    }
+}
+
+void WriteSwizzlePatternsOffset(bool gs, u32 value) {
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    config.swizzle_patterns.offset = value;
+}
+
+void WriteSwizzlePatterns(bool gs, u32 value) {
+    const char* shader_type = gs ? "GS" : "VS";
+    auto& config = gs ? g_state.regs.gs : g_state.regs.vs;
+    auto& setup = gs ? g_state.gs : g_state.vs;
+
+    if (config.swizzle_patterns.offset >= setup.swizzle_data.size()) {
+        LOG_ERROR(HW_GPU, "Invalid %s swizzle pattern offset %d", shader_type,
+                  (int)config.swizzle_patterns.offset);
+    } else {
+        setup.swizzle_data[config.swizzle_patterns.offset] = value;
+        config.swizzle_patterns.offset++;
+    }
+}
+
 } // namespace Shader
 
 } // namespace Pica

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -144,8 +144,8 @@ struct ShaderSetup {
         return offsetof(ShaderSetup, uniforms.i) + index * sizeof(Math::Vec4<u8>);
     }
 
-    std::array<u32, 1024> program_code;
-    std::array<u32, 1024> swizzle_data;
+    std::array<u32, 4096> program_code;
+    std::array<u32, 4096> swizzle_data;
 
     /// Data private to ShaderEngines
     struct EngineData {

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -144,6 +144,9 @@ struct ShaderSetup {
         return offsetof(ShaderSetup, uniforms.i) + index * sizeof(Math::Vec4<u8>);
     }
 
+    int float_regs_counter = 0;
+    u32 uniform_write_buffer[4];
+
     std::array<u32, 4096> program_code;
     std::array<u32, 4096> swizzle_data;
 
@@ -177,6 +180,16 @@ public:
 // TODO(yuriks): Remove and make it non-global state somewhere
 ShaderEngine* GetEngine();
 void Shutdown();
+
+bool SharedGS();
+void WriteUniformBoolReg(bool gs, u32 value);
+void WriteUniformIntReg(bool gs, unsigned index, const Math::Vec4<u8>& values);
+void WriteUniformFloatSetupReg(bool gs, u32 value);
+void WriteUniformFloatReg(bool gs, u32 value);
+void WriteProgramCodeOffset(bool gs, u32 value);
+void WriteProgramCode(bool gs, u32 value);
+void WriteSwizzlePatternsOffset(bool gs, u32 value);
+void WriteSwizzlePatterns(bool gs, u32 value);
 
 } // namespace Shader
 

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -653,7 +653,7 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
 }
 
 void InterpreterEngine::SetupBatch(ShaderSetup& setup, unsigned int entry_point) {
-    ASSERT(entry_point < 1024);
+    ASSERT(entry_point < 4096);
     setup.engine_data.entry_point = entry_point;
 }
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -15,7 +15,7 @@ JitX64Engine::JitX64Engine() = default;
 JitX64Engine::~JitX64Engine() = default;
 
 void JitX64Engine::SetupBatch(ShaderSetup& setup, unsigned int entry_point) {
-    ASSERT(entry_point < 1024);
+    ASSERT(entry_point < 4096);
     setup.engine_data.entry_point = entry_point;
 
     u64 code_hash = Common::ComputeHash64(&setup.program_code, sizeof(setup.program_code));

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -834,8 +834,8 @@ void JitShader::FindReturnOffsets() {
     std::sort(return_offsets.begin(), return_offsets.end());
 }
 
-void JitShader::Compile(const std::array<u32, 1024>* program_code_,
-                        const std::array<u32, 1024>* swizzle_data_) {
+void JitShader::Compile(const std::array<u32, 4096>* program_code_,
+                        const std::array<u32, 4096>* swizzle_data_) {
     program_code = program_code_;
     swizzle_data = swizzle_data_;
 

--- a/src/video_core/shader/shader_jit_x64_compiler.h
+++ b/src/video_core/shader/shader_jit_x64_compiler.h
@@ -22,8 +22,8 @@ namespace Pica {
 
 namespace Shader {
 
-/// Memory allocated for each compiled shader (64Kb)
-constexpr size_t MAX_SHADER_SIZE = 1024 * 64;
+/// Memory allocated for each compiled shader (256Kb)
+constexpr size_t MAX_SHADER_SIZE = 1024 * 256;
 
 /**
  * This class implements the shader JIT compiler. It recompiles a Pica shader program into x86_64
@@ -37,8 +37,8 @@ public:
         program(&setup, &state, instruction_labels[offset].getAddress());
     }
 
-    void Compile(const std::array<u32, 1024>* program_code,
-                 const std::array<u32, 1024>* swizzle_data);
+    void Compile(const std::array<u32, 4096>* program_code,
+                 const std::array<u32, 4096>* swizzle_data);
 
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
@@ -104,11 +104,11 @@ private:
      */
     void FindReturnOffsets();
 
-    const std::array<u32, 1024>* program_code = nullptr;
-    const std::array<u32, 1024>* swizzle_data = nullptr;
+    const std::array<u32, 4096>* program_code = nullptr;
+    const std::array<u32, 4096>* swizzle_data = nullptr;
 
     /// Mapping of Pica VS instructions to pointers in the emitted code
-    std::array<Xbyak::Label, 1024> instruction_labels;
+    std::array<Xbyak::Label, 4096> instruction_labels;
 
     /// Offsets in code where a return needs to be inserted
     std::vector<unsigned> return_offsets;


### PR DESCRIPTION
This code is part of the geometry shader (GS) implementation written by me which is based on work by @ds84182 .

This PR shouldn't change any behaviour currently (except maybe for cases where GS is active, but those are bugged anyway). It merely prepares the registers for GS.
I'd recommend inclusion in bleeding-edge to figure out if there are any issues.

Review per commit; following is an explanation of each.

---

### Pica/Regs: Prepare for GS

Introduces the registers related to the GS.

*Note that some of the registers will be unused for a while (until the next PR at least). Shall I mark them with `// Unused` or something?*


### Pica: Set program code / swizzle data limit to 4096

One of the later commits will enable writing to GS regs.
It turns out that on startup, most games will write 4096 GS program words.

The current limit of 1024 would hence result in 3072 (4096 - 1024) error messages:
```
HW.GPU <Error> video_core/shader/shader.cpp:WriteProgramCode:229: Invalid GS program offset 1024
```

The swizzle data size has also been raised. This matches the given field sizes of [GPUREG_SH_OPDESCS_INDEX](https://3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_SH_OPDESCS_INDEX) and [GPUREG_SH_CODETRANSFER_INDEX](https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_SH_CODETRANSFER_INDEX)

*The limit for VS (Vertex Shaders) appears to be 512 program words. We should probably introduce a template parameter or something to handle these differences between VS / GS structure. However, that's beyond the scope of this PR. I can create an issue for this.*


### Pica: Write shader registers in functions

We'll soon have to handle all shader related writes for both, VS and GS. So I moved the handler into a function.

`vsh_com_mode` is indicating if GS will use the same shader data (uniform / program / swizzle data) as VS.

It is not yet known if this influences writes (the functions introduced in this commit) OR reads (in the interpreter and jit).
We also don't know wether the shader data is per shader mode (VS / GS) or per shader-unit (4 units, only one of which is able to run GS).
However, this should be easy to change in the future if the current implementation is wrong.

*= We need a couple of hardware tests to understand how the shader data is uploaded. However, I vote for accepting this for now, and refactoring later once hardware tests have been done.*

*Another little annoyance with this commit is that the functions take a `bool` as first argument for false = VS / true = GS. Shall I change that to an enum class or something else or leave as-is?*


### Pica: Write GS registers

This adds the handlers for the geometry shader register writes which will call the functions from the previous commit to update registers for the GS.

---

TODO:

- [ ] PR desc
- [ ] Cleanup
- [ ] Testing